### PR TITLE
fix: Release-plz should clear cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Install needed Ubuntu Deps
         run: sudo apt install libdbus-1-dev pkg-config libudev-dev
+      - name: clear cache
+        run: cargo clean
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@main
         env:


### PR DESCRIPTION
Not sure why it's still there given that it doesn't use a cache action but this should clear the target dir before starting the release.