### PR TITLE
feat: remove mentions of stellar registry install

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,6 @@ stellar registry deploy \
   --wasm-name my-contract \
   -- \
   --help
-
-# Install the deployed contract locally for use with stellar-cli
-stellar registry install my-contract-instance
 ```
 
 ## Project Layout
@@ -140,7 +137,6 @@ Manage contract deployment and versions:
 ```
 stellar registry publish --wasm contract.wasm --wasm-name my-contract    # Publish contract to the registry
 stellar registry deploy --contract-name instance --wasm-name my-contract # Deploy a contract instance
-stellar registry install my-contract-instance                           # Install deployed contracts locally
 ```
 > Use `--help` on any command for usage instructions.
 
@@ -177,12 +173,7 @@ stellar registry deploy \
   --decimals 7
 ```
 
-### 3. Install the Deployed Contract
-```bash
-stellar registry install my-contract-instance
-```
-
-After installation, you can interact with the contract using `stellar-cli`:
+After deployment, you can interact with the contract using `stellar-cli`:
 ```bash
 stellar contract invoke --id my-contract-instance -- --help
 ```
@@ -200,7 +191,6 @@ The registry is an on-chain smart contract that lets you:
 The registry separates the concepts of:
 - **WASM publication**: Publishing reusable contract code
 - **Contract deployment**: Creating instances of published contracts
-- **Local installation**: Creating aliases for easy CLI access
 
 >This means your contracts can be upgraded, shared, and used like packages.
 

--- a/crates/stellar-registry-cli/README.md
+++ b/crates/stellar-registry-cli/README.md
@@ -1,6 +1,6 @@
 # stellar-registry-cli
 
-Command line interface for managing smart contract deployments through the Stellar Registry system. This tool enables publishing, deploying, and installing contracts that have been published to the Stellar Registry.
+Command line interface for managing smart contract deployments through the Stellar Registry system. This tool enables publishing and deploying contracts that have been published to the Stellar Registry.
 
 ## Installation
 
@@ -58,16 +58,6 @@ Options:
 
 Note: Use `--` to separate CLI options from constructor function and arguments.
 
-### Install
-
-Install a deployed contract as an alias to be used by `stellar-cli`:
-```bash
-stellar registry install <CONTRACT_NAME>
-```
-
-Options:
-- `CONTRACT_NAME`: Name of the deployed contract to install (required)
-
 ## Configuration
 
 `stellar-cli` provides a way to use a default config for accounts and networks:
@@ -110,11 +100,6 @@ stellar registry deploy \
   --name "My Token" \
   --symbol "MTK" \
   --decimals 7
-```
-
-3. Install the deployed contract:
-```bash
-stellar registry install my-token
 ```
 
 Then can interact with the contract with `stellar-cli`:

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -60,17 +60,6 @@ Options:
 
 Note: Use `--` to separate CLI options from constructor function and arguments.
 
-### Install Contract
-
-Install a deployed contract as an alias to be used by `stellar-cli`:
-
-```bash
-stellar registry install <CONTRACT_NAME>
-```
-
-Options:
-- `CONTRACT_NAME`: Name of the deployed contract to install (required)
-
 ## Configuration
 
 The registry CLI respects the following environment variables:
@@ -112,12 +101,7 @@ stellar registry deploy \
   --decimals 7
 ```
 
-3. Install the deployed contract locally:
-```bash
-stellar registry install my-token
-```
-
-4. Use the installed contract with `stellar-cli`:
+3. Use the deployed contract with `stellar-cli`:
 ```bash
 stellar contract invoke --id my-token -- --help
 ```


### PR DESCRIPTION
Depends on #176

For now just remove mentions of install. I think in the end making the alias should be done by default after `stellar registry deploy`. Just as it is done when calling `stellar contract deploy`.