### PR TITLE
fix: build clients if they do not exist

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential binutils
+      - name: Set environment for cc-rs
+        run: |
+          echo "CC=gcc" >> $GITHUB_ENV
+          echo "AR=ar" >> $GITHUB_ENV
       - uses: actions/cache@v3
         with:
           path: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +316,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +351,88 @@ dependencies = [
  "pin-project-lite",
  "tokio 1.44.2",
 ]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg 1.4.0",
+ "cfg-if 1.0.0",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.2",
+ "slab",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if 1.0.0",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.2",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if 1.0.0",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.2",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -469,6 +586,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "bollard"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,7 +658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
 dependencies = [
  "memchr",
- "regex-automata 0.4.9",
+ "regex-automata",
  "serde",
 ]
 
@@ -619,6 +758,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +825,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.1.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -807,6 +965,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes 1.10.1",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils 0.8.21",
 ]
 
 [[package]]
@@ -952,7 +1119,7 @@ dependencies = [
  "crossbeam-utils 0.7.2",
  "lazy_static",
  "maybe-uninit",
- "memoffset",
+ "memoffset 0.5.6",
  "scopeguard",
 ]
 
@@ -1203,11 +1370,16 @@ version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42a16374481d92aed73ae45b1f120207d8e71d24fb89f357fadbd8f946fd84b"
 dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
  "dbus",
  "futures-util",
+ "hkdf",
  "num",
  "once_cell",
  "rand 0.8.5",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1488,6 +1660,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,6 +1713,27 @@ name = "ethnum"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "failure"
@@ -1743,6 +1963,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1842,8 +2075,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2012,6 +2245,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -2527,7 +2769,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata 0.4.9",
+ "regex-automata",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -2626,6 +2868,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -2853,6 +3105,7 @@ dependencies = [
  "byteorder 1.5.0",
  "dbus-secret-service",
  "log",
+ "secret-service",
  "security-framework 2.11.1",
  "security-framework 3.2.0",
  "windows-sys 0.59.0",
@@ -2976,9 +3229,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -3082,11 +3335,11 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -3112,6 +3365,15 @@ name = "memoffset"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+dependencies = [
+ "autocfg 1.4.0",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg 1.4.0",
 ]
@@ -3248,6 +3510,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if 1.0.0",
+ "cfg_aliases",
+ "libc",
+ "memoffset 0.9.1",
+]
+
+[[package]]
 name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3280,12 +3555,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi 0.3.9",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3524,10 +3798,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "overload"
-version = "0.1.1"
+name = "ordered-stream"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "p256"
@@ -3540,6 +3818,12 @@ dependencies = [
  "primeorder",
  "sha2 0.10.9",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -3698,6 +3982,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3712,6 +4007,20 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if 1.0.0",
+ "concurrent-queue",
+ "hermit-abi 0.5.1",
+ "pin-project-lite",
+ "rustix 1.1.2",
+ "windows-sys 0.61.0",
+]
 
 [[package]]
 name = "powerfmt"
@@ -3803,6 +4112,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -4122,17 +4440,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -4143,14 +4452,8 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -4385,15 +4688,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.3",
- "windows-sys 0.59.0",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -4569,6 +4872,25 @@ dependencies = [
  "generic-array",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.10.9",
+ "zbus",
 ]
 
 [[package]]
@@ -4784,6 +5106,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4978,9 +5311,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-cli"
-version = "23.0.0"
+version = "23.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60aabd55466ed376cd9f80fbeabe0bf81466d26292d2e074d89e61d1e39aaa10"
+checksum = "8623aa151b96b6199b27c889b73ac7be93533c07ca5df244edd5a1c573713e66"
 dependencies = [
  "async-compression",
  "async-trait",
@@ -5038,9 +5371,10 @@ dependencies = [
  "soroban-spec-rust 23.0.2",
  "soroban-spec-tools",
  "soroban-spec-typescript",
+ "stellar-asset-spec",
  "stellar-ledger",
  "stellar-rpc-client",
- "stellar-strkey 0.0.11",
+ "stellar-strkey 0.0.13",
  "stellar-xdr 23.0.0",
  "strsim 0.11.1",
  "strum 0.17.1",
@@ -5359,9 +5693,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-json"
-version = "23.0.0"
+version = "23.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7deeab655fce48bdb15013e995cfa651f745feae5659af650a9f86b80920390"
+checksum = "77dd602208a4716b401260db89da18179f38aefddf55b90f169d9dd45b791a9e"
 dependencies = [
  "serde",
  "serde_derive",
@@ -5406,9 +5740,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-tools"
-version = "23.0.0"
+version = "23.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980452b0f9b9db42004aecceae4138482ee6afce5a7dbe21e5f4a2d9fcc30a8d"
+checksum = "66037fdfb7857aaea8b2fa3c81c7949dd7ed41568c4d5e53c1a80fb6c12d98ad"
 dependencies = [
  "base64 0.21.7",
  "ethnum",
@@ -5416,7 +5750,7 @@ dependencies = [
  "itertools 0.10.5",
  "serde_json",
  "soroban-spec 23.0.2",
- "stellar-strkey 0.0.11",
+ "stellar-strkey 0.0.13",
  "stellar-xdr 23.0.0",
  "thiserror 1.0.69",
  "wasmparser",
@@ -5424,9 +5758,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-typescript"
-version = "23.0.1"
+version = "23.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ed4459149655b4e6e0430e96534fd5176733c4842c97109a49a9bfc62bf7a9"
+checksum = "0fe6e04fbd60fd774676a66475650e52f326d58addc41c856a046cc2f52db901"
 dependencies = [
  "base64 0.21.7",
  "heck 0.4.1",
@@ -5440,6 +5774,25 @@ dependencies = [
  "soroban-spec 23.0.2",
  "stellar-xdr 23.0.0",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "soroban-token-sdk"
+version = "23.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f6124c98e1919cd71186553a70b6bd7be8b032aacbb91dd033bf4b02616c3a9"
+dependencies = [
+ "soroban-sdk 23.0.2",
+]
+
+[[package]]
+name = "soroban-token-spec"
+version = "23.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79ab6a6940dc083e3ad979affd4511f4dcb0783a267b98dca3c1f6c561a4e40c"
+dependencies = [
+ "soroban-sdk 23.0.2",
+ "soroban-token-sdk",
 ]
 
 [[package]]
@@ -5484,6 +5837,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "stellar-asset-spec"
+version = "23.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b7d0cd5bf3557d26abba06fc649b7c49c1f991d66327d3aea8fe055f4527f1b"
+dependencies = [
+ "soroban-sdk 23.0.2",
+ "soroban-token-sdk",
+ "soroban-token-spec",
+]
+
+[[package]]
 name = "stellar-build"
 version = "0.0.2"
 dependencies = [
@@ -5494,9 +5858,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-ledger"
-version = "23.0.0"
+version = "23.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ddb5f5a9fa80cf44e4750afa88c233e02bd951c4be1d90e6b1c266db5bc14f"
+checksum = "88bbdf3a4857cae76def9925086289ed831c62c457db8461e84644a3f4acd648"
 dependencies = [
  "async-trait",
  "bollard",
@@ -5512,7 +5876,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "slipped10",
- "stellar-strkey 0.0.11",
+ "stellar-strkey 0.0.13",
  "stellar-xdr 23.0.0",
  "thiserror 1.0.69",
  "tokio 1.44.2",
@@ -5552,9 +5916,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-rpc-client"
-version = "23.0.0-rc.5"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68db799e1a626da3b2ab34d8e3ddca9657f83552588154f0a68b6071199b691f"
+checksum = "0c8dde56ff1db696f25238cbf42fd6abc1c8f0b9b34406d9297723935549db63"
 dependencies = [
  "clap 4.5.35",
  "hex",
@@ -5918,7 +6282,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.5",
+ "rustix 1.1.2",
  "windows-sys 0.59.0",
 ]
 
@@ -6467,14 +6831,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec 1.15.0",
  "thread_local",
@@ -6503,6 +6867,17 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "uds_windows"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+dependencies = [
+ "memoffset 0.9.1",
+ "tempfile",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "ulid"
@@ -7432,7 +7807,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
 dependencies = [
  "libc",
- "rustix 1.0.5",
+ "rustix 1.1.2",
+]
+
+[[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7457,6 +7842,62 @@ dependencies = [
  "quote",
  "syn 2.0.100",
  "synstructure 0.13.1",
+]
+
+[[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "rand 0.8.5",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
 ]
 
 [[package]]
@@ -7556,6 +7997,43 @@ name = "zerovec-derive"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,19 +811,6 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width 0.2.0",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "console"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
@@ -1286,7 +1273,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
 dependencies = [
- "console 0.16.1",
+ "console",
  "shell-words",
  "tempfile",
  "zeroize",
@@ -1368,7 +1355,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2614,7 +2601,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c60da1c9abea75996b70a931bba6c750730399005b61ccd853cee50ef3d0d0c"
 dependencies = [
- "console 0.15.11",
+ "console",
  "lazy_static",
  "number_prefix",
  "parking_lot 0.12.3",
@@ -4979,9 +4966,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "23.0.0-rc.2"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae7f1f1908c9cdb7740eb9bb7a467770ff26fa4c82e49fdb4de88027b5fb93c"
+checksum = "d9336adeabcd6f636a4e0889c8baf494658ef5a3c4e7e227569acd2ce9091e85"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -5044,17 +5031,17 @@ dependencies = [
  "sha2 0.10.9",
  "shell-escape",
  "shlex",
- "soroban-ledger-snapshot 23.0.0-rc.2.2",
- "soroban-sdk 23.0.0-rc.2.2",
- "soroban-spec 23.0.0-rc.2.2",
+ "soroban-ledger-snapshot 23.0.2",
+ "soroban-sdk 23.0.2",
+ "soroban-spec 23.0.2",
  "soroban-spec-json",
- "soroban-spec-rust 23.0.0-rc.2.2",
+ "soroban-spec-rust 23.0.2",
  "soroban-spec-tools",
  "soroban-spec-typescript",
  "stellar-ledger",
  "stellar-rpc-client",
  "stellar-strkey 0.0.11",
- "stellar-xdr 23.0.0-rc.2",
+ "stellar-xdr 23.0.0",
  "strsim 0.11.1",
  "strum 0.17.1",
  "strum_macros 0.17.1",
@@ -5100,19 +5087,19 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "23.0.0-rc.2"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c20fd873e412036f93916c946d497216d8a997a5f8c13a342127fe0043cde49"
+checksum = "00067f52e8bbf1abf0de03fe3e2fbb06910893cfbe9a7d9093d6425658833ff3"
 dependencies = [
  "crate-git-revision",
  "ethnum",
  "num-derive",
  "num-traits",
  "serde",
- "soroban-env-macros 23.0.0-rc.2",
+ "soroban-env-macros 23.0.1",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 23.0.0-rc.2",
+ "stellar-xdr 23.0.0",
  "wasmparser",
 ]
 
@@ -5128,11 +5115,11 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "23.0.0-rc.2"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f18662e41bcfc9914ec365c3743ac040513403f1ca2cc7bad0a7a846f179391c"
+checksum = "ccd1e40963517b10963a8e404348d3fe6caf9c278ac47a6effd48771297374d6"
 dependencies = [
- "soroban-env-common 23.0.0-rc.2",
+ "soroban-env-common 23.0.1",
  "static_assertions",
 ]
 
@@ -5174,9 +5161,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "23.0.0-rc.2"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a03f55efb228e2b687276a4171291c814b7ee38d2aed926d7cb5a786bf269a"
+checksum = "b9766c5ad78e9d8ae10afbc076301f7d610c16407a1ebb230766dbe007a48725"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -5200,8 +5187,8 @@ dependencies = [
  "sec1",
  "sha2 0.10.9",
  "sha3",
- "soroban-builtin-sdk-macros 23.0.0-rc.2",
- "soroban-env-common 23.0.0-rc.2",
+ "soroban-builtin-sdk-macros 23.0.1",
+ "soroban-env-common 23.0.1",
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey 0.0.13",
@@ -5225,16 +5212,16 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "23.0.0-rc.2"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273c716dcf8797dd70517cc79af7b788934a17ced73a156bd6511f51930d4cd7"
+checksum = "b0e6a1c5844257ce96f5f54ef976035d5bd0ee6edefaf9f5e0bcb8ea4b34228c"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr 23.0.0-rc.2",
+ "stellar-xdr 23.0.0",
  "syn 2.0.100",
 ]
 
@@ -5254,15 +5241,15 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "23.0.0-rc.2.2"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ebf958cfc8e9587b0ab5d79e6ce3ab8863c5210ed1d6e9de7c9c29a6168c1e"
+checksum = "3823372b72cab2e7ff2ced62bbffa11fce8da0713a224f122141558cab174647"
 dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "soroban-env-common 23.0.0-rc.2",
- "soroban-env-host 23.0.0-rc.2",
+ "soroban-env-common 23.0.1",
+ "soroban-env-host 23.0.1",
  "thiserror 1.0.69",
 ]
 
@@ -5290,9 +5277,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "23.0.0-rc.2.2"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ec405c6d289f4efe5c4e54bbe85b5d8cd15d388ac43f396f77a93cf9c00e7c"
+checksum = "af0e5bf6702f5952d78c5b2bcd05b0349f9a570cc62028d90dac3710b40cbe65"
 dependencies = [
  "bytes-lit",
  "crate-git-revision",
@@ -5300,9 +5287,9 @@ dependencies = [
  "rustc_version 0.4.1",
  "serde",
  "serde_json",
- "soroban-env-guest 23.0.0-rc.2",
- "soroban-env-host 23.0.0-rc.2",
- "soroban-sdk-macros 23.0.0-rc.2.2",
+ "soroban-env-guest 23.0.1",
+ "soroban-env-host 23.0.1",
+ "soroban-sdk-macros 23.0.2",
  "stellar-strkey 0.0.13",
 ]
 
@@ -5328,9 +5315,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "23.0.0-rc.2.2"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66fe748e50648fda04f74a128bac9eaf0bf028e7015c75b9fb83ab87d5ef1be8"
+checksum = "b38abe20199c5d9fbff232381aa4e8e83302b34e82e38fbb090f41f1284fc920"
 dependencies = [
  "darling",
  "heck 0.5.0",
@@ -5339,10 +5326,10 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2 0.10.9",
- "soroban-env-common 23.0.0-rc.2",
- "soroban-spec 23.0.0-rc.2.2",
- "soroban-spec-rust 23.0.0-rc.2.2",
- "stellar-xdr 23.0.0-rc.2",
+ "soroban-env-common 23.0.1",
+ "soroban-spec 23.0.2",
+ "soroban-spec-rust 23.0.2",
+ "stellar-xdr 23.0.0",
  "syn 2.0.100",
 ]
 
@@ -5360,12 +5347,12 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "23.0.0-rc.2.2"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4762bd2702b9955bfe8100125b3efbf4b72c71f6f9b509ed0bdc9b9797e54b1"
+checksum = "72526d30f8825b859afa7e0b94549dad05c58a6c928b0763620412744512d7e2"
 dependencies = [
  "base64 0.22.1",
- "stellar-xdr 23.0.0-rc.2",
+ "stellar-xdr 23.0.0",
  "thiserror 1.0.69",
  "wasmparser",
 ]
@@ -5380,8 +5367,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.9.9",
- "soroban-spec 23.0.0-rc.2.2",
- "stellar-xdr 23.0.0-rc.2",
+ "soroban-spec 23.0.2",
+ "stellar-xdr 23.0.0",
  "thiserror 1.0.69",
 ]
 
@@ -5403,16 +5390,16 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "23.0.0-rc.2.2"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b38c19691b6acc70642b59c2476ca603f3043a243baae31ffb7b1164d92451"
+checksum = "9088cb8307dad026cda494971c4f13c76f9427ab26becb7cd691da95dc5e9b1d"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
  "sha2 0.10.9",
- "soroban-spec 23.0.0-rc.2.2",
- "stellar-xdr 23.0.0-rc.2",
+ "soroban-spec 23.0.2",
+ "stellar-xdr 23.0.0",
  "syn 2.0.100",
  "thiserror 1.0.69",
 ]
@@ -5428,9 +5415,9 @@ dependencies = [
  "hex",
  "itertools 0.10.5",
  "serde_json",
- "soroban-spec 23.0.0-rc.2.2",
+ "soroban-spec 23.0.2",
  "stellar-strkey 0.0.11",
- "stellar-xdr 23.0.0-rc.2",
+ "stellar-xdr 23.0.0",
  "thiserror 1.0.69",
  "wasmparser",
 ]
@@ -5450,8 +5437,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.9.9",
- "soroban-spec 23.0.0-rc.2.2",
- "stellar-xdr 23.0.0-rc.2",
+ "soroban-spec 23.0.2",
+ "stellar-xdr 23.0.0",
  "thiserror 1.0.69",
 ]
 
@@ -5526,7 +5513,7 @@ dependencies = [
  "sha2 0.10.9",
  "slipped10",
  "stellar-strkey 0.0.11",
- "stellar-xdr 23.0.0-rc.2",
+ "stellar-xdr 23.0.0",
  "thiserror 1.0.69",
  "tokio 1.44.2",
  "tracing",
@@ -5558,7 +5545,7 @@ dependencies = [
  "soroban-spec-tools",
  "stellar-rpc-client",
  "stellar-scaffold-test",
- "stellar-strkey 0.0.11",
+ "stellar-strkey 0.0.13",
  "thiserror 1.0.69",
  "tokio 1.44.2",
 ]
@@ -5581,7 +5568,7 @@ dependencies = [
  "serde_with",
  "sha2 0.10.9",
  "stellar-strkey 0.0.9",
- "stellar-xdr 23.0.0-rc.2",
+ "stellar-xdr 23.0.0",
  "termcolor",
  "termcolor_output",
  "thiserror 1.0.69",
@@ -5627,8 +5614,8 @@ dependencies = [
  "stellar-build",
  "stellar-rpc-client",
  "stellar-scaffold-test",
- "stellar-strkey 0.0.11",
- "stellar-xdr 23.0.0-rc.2",
+ "stellar-strkey 0.0.13",
+ "stellar-xdr 23.0.0",
  "strsim 0.11.1",
  "symlink",
  "tar",
@@ -5662,7 +5649,7 @@ dependencies = [
  "assert_fs",
  "fs_extra",
  "soroban-cli",
- "soroban-sdk 23.0.0-rc.2.2",
+ "soroban-sdk 23.0.2",
  "stellar-registry-cli",
  "stellar-scaffold-cli",
  "tokio 1.44.2",
@@ -5730,9 +5717,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "23.0.0-rc.2"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632bf15309c2992c059fb499275a706f6afdfd68c690508d5d9bfa96c771477f"
+checksum = "89d2848e1694b0c8db81fd812bfab5ea71ee28073e09ccc45620ef3cf7a75a9b"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ stellar-registry = { path = "crates/stellar-registry" }
 
 loam-sdk = { git = "https://github.com/loambuild/loam", rev = "096da30cedd371651906cfbed034b955c7b50ab4" }
 loam-subcontract-core = { git = "https://github.com/loambuild/loam", rev = "096da30cedd371651906cfbed034b955c7b50ab4" }
-stellar-cli = { version = "23.0.0", package = "soroban-cli" }
-soroban-rpc = { package = "stellar-rpc-client", version = "23.0.0-rc.5" }
+stellar-cli = { version = "23.1.3", package = "soroban-cli" }
+soroban-rpc = { package = "stellar-rpc-client", version = "23.0.1" }
 soroban-spec-tools = "23.0.0"
 
 soroban-sdk = "23.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ stellar-cli = { version = "23.0.0", package = "soroban-cli" }
 soroban-rpc = { package = "stellar-rpc-client", version = "23.0.0-rc.5" }
 soroban-spec-tools = "23.0.0"
 
-soroban-sdk = "23.0.0-rc.2.1"
-stellar-xdr = "23.0.0-rc.2"
-stellar-strkey = "0.0.11"
+soroban-sdk = "23.0.2"
+stellar-xdr = "23.0.0"
+stellar-strkey = "0.0.13"
 
 cargo_metadata = "0.18.1"
 thiserror = "1.0.38"

--- a/crates/stellar-scaffold-cli/src/commands/build/clients.rs
+++ b/crates/stellar-scaffold-cli/src/commands/build/clients.rs
@@ -651,6 +651,18 @@ export default new Client.Client({{
         Ok(())
     }
 
+    fn get_package_dir(&self, name: &str) -> Result<std::path::PathBuf, Error> {
+        let workspace_root = self
+            .workspace_root
+            .as_ref()
+            .expect("workspace_root must be set before running");
+        let package_dir = workspace_root.join(format!("packages/{name}"));
+        if !package_dir.exists() {
+            return Err(Error::BadContractName(name.to_string()));
+        }
+        Ok(package_dir)
+    }
+
     async fn process_single_contract(
         &self,
         name: &str,
@@ -678,6 +690,14 @@ export default new Client.Client({{
                 if let Some(current_hash) = hash {
                     if current_hash == new_hash {
                         printer.checkln(format!("Contract {name:?} is up to date"));
+                        // If there is not a package at packages/<name>, generate bindings
+                        if self.get_package_dir(name).is_err() {
+                            self.generate_contract_bindings(
+                                name,
+                                &existing_contract_id.to_string(),
+                            )
+                            .await?;
+                        }
                         return Ok(());
                     }
                     upgraded_contract = self
@@ -992,5 +1012,46 @@ async fn fetch_contract_spec(
     match fetched.contract {
         contract_spec::Contract::Wasm { wasm_bytes } => Ok(Spec::new(&wasm_bytes)?.spec),
         contract_spec::Contract::StellarAssetContract => unreachable!(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_get_package_dir() {
+        // create a folder at this temporary path for the test
+        let temp_dir = TempDir::new().unwrap();
+        let package_path = temp_dir.path().join("packages/existing_package");
+        std::fs::create_dir_all(&package_path).unwrap();
+        let args = Args {
+            env: Some(ScaffoldEnv::Development),
+            workspace_root: Some(temp_dir.path().to_path_buf()),
+            out_dir: None,
+            global_args: None,
+        };
+        let result = args.get_package_dir("existing_package");
+        assert!(result.is_ok());
+        let path = result.unwrap();
+        assert_eq!(path.file_name().unwrap(), "existing_package");
+    }
+
+    #[test]
+    fn test_get_package_dir_nonexistent() {
+        let args = Args {
+            env: Some(ScaffoldEnv::Development),
+            workspace_root: Some(std::path::PathBuf::from("tests/nonexistent_workspace")),
+            out_dir: None,
+            global_args: None,
+        };
+        let result = args.get_package_dir("nonexistent_package");
+        assert!(result.is_err());
+        if let Err(Error::BadContractName(name)) = result {
+            assert_eq!(name, "nonexistent_package");
+        } else {
+            panic!("Expected BadContractName error");
+        }
     }
 }

--- a/crates/stellar-scaffold-cli/src/commands/build/clients.rs
+++ b/crates/stellar-scaffold-cli/src/commands/build/clients.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::struct_excessive_bools)]
+#![allow(clippy::struct_excessive_bools, clippy::result_large_err)]
 use super::env_toml::Network;
 use crate::arg_parsing;
 use crate::arg_parsing::ArgParser;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.89.0"
 targets = ["wasm32v1-none"]


### PR DESCRIPTION
In the case where you've removed the folders in your packages/ folder, scaffold stellar will never rebuild the clients if the hash matches. Add a check for this.