### PR TITLE
fix: default to development environment

### DIFF
--- a/crates/stellar-scaffold-cli/src/commands/build/clients.rs
+++ b/crates/stellar-scaffold-cli/src/commands/build/clients.rs
@@ -135,7 +135,7 @@ impl Args {
 
         let Some(current_env) = env_toml::Environment::get(
             workspace_root,
-            &self.stellar_scaffold_env(ScaffoldEnv::Production),
+            &self.stellar_scaffold_env(ScaffoldEnv::Development),
         )?
         else {
             return Ok(());


### PR DESCRIPTION
The default environment should be development instead of production. The first experience of Scaffold is most likely going to be to develop something locally. Regardless, as a best practice, people must always be deliberate if they intent to deploy on mainnet as to not break things on their side.