### PR TITLE
docs: Light mode only

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -87,8 +87,8 @@ const config: Config = {
     ],
     colorMode: {
       defaultMode: 'light',
-      disableSwitch: false,
-      respectPrefersColorScheme: true,
+      disableSwitch: true,
+      respectPrefersColorScheme: false,
     },
     navbar: {
       title: 'Scaffold Stellar',


### PR DESCRIPTION
Updated settings per https://docusaurus.io/docs/api/themes/configuration/#color-mode---dark-mode to enforce light mode