### PR TITLE
fix(init): remove obsolete OpenZeppelin fungible-token-interface 

### DIFF
--- a/crates/stellar-scaffold-cli/src/commands/init.rs
+++ b/crates/stellar-scaffold-cli/src/commands/init.rs
@@ -86,12 +86,6 @@ impl Cmd {
         }
 
         // Update the project with the latest OpenZeppelin examples
-        self.update_oz_example(
-            &absolute_project_path,
-            "fungible-token-interface",
-            global_args,
-        )
-        .await?;
         self.update_oz_example(&absolute_project_path, "nft-enumerable", global_args)
             .await?;
 


### PR DESCRIPTION
Removes the `fungible-token-interface` example, which was removed from the OpenZeppelin contract library and caused init to error.
Fixes #257.