### PR TITLE
build: Remove always from cache restore step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
       - run: just test-integration
       - name: Always Save Cache
         id: cache-save
-        if: always() && steps.cache-restore.outputs.cache-hit != 'true'
+        if: steps.cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: |


### PR DESCRIPTION
On the main branch, the workflows are hanging on this cache step, and this `always` doesn't look good. This means it would always run, including on failed and cancelled jobs.