### PR TITLE
build: remove target from cache save

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,5 +76,4 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             crates/stellar-scaffold-test/fixtures/soroban-init-boilerplate/target/
-            target/
           key: ${{ steps.cache-restore.outputs.cache-primary-key }}


### PR DESCRIPTION
Remove `target/` folder from cache save, it will be large and I suspect it's why we're running out of space, such that builds on `main` fail:

<img width="1430" height="428" alt="image" src="https://github.com/user-attachments/assets/7e252473-6823-4dba-87e1-babd55800fb0" />
