### PR TITLE
Asset macro rework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -230,6 +241,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,6 +380,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +454,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +492,28 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "byteorder"
@@ -1336,6 +1410,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1546,6 +1626,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1553,7 +1636,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
 ]
 
 [[package]]
@@ -2856,12 +2939,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+dependencies = [
+ "toml_edit 0.23.7",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2933,6 +3045,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -3088,6 +3206,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3155,6 +3282,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rpassword"
 version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3207,6 +3363,22 @@ checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
 dependencies = [
  "sha2 0.10.9",
  "walkdir",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35affe401787a9bd846712274d97654355d21b2a2c092a3139aabe31e9022282"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3427,6 +3599,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
@@ -3722,6 +3900,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3863,7 +4047,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml 0.8.23",
- "toml_edit",
+ "toml_edit 0.22.27",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -4348,7 +4532,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml 0.9.8",
- "toml_edit",
+ "toml_edit 0.22.27",
  "uuid",
  "walkdir",
  "webbrowser",
@@ -4361,7 +4545,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
+ "rust_decimal",
  "sha2 0.10.9",
+ "soroban-sdk 23.0.2",
  "stellar-build",
  "stellar-strkey 0.0.13",
  "stellar-xdr",
@@ -4513,6 +4699,12 @@ dependencies = [
  "quote",
  "syn 2.0.110",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -4786,7 +4978,7 @@ dependencies = [
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
- "toml_edit",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -4833,6 +5025,18 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
+dependencies = [
+ "indexmap 2.12.0",
+ "toml_datetime 0.7.3",
+ "toml_parser",
  "winnow",
 ]
 
@@ -5755,6 +5959,15 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "xattr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,17 +18,6 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.16",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -241,12 +230,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,18 +363,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,29 +425,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "borsh"
-version = "1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
-dependencies = [
- "borsh-derive",
- "cfg_aliases",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
-dependencies = [
- "once_cell",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.110",
-]
-
-[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,28 +440,6 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
-
-[[package]]
-name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "byteorder"
@@ -1410,12 +1336,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1626,9 +1546,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1636,7 +1553,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
 ]
 
 [[package]]
@@ -2939,41 +2856,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
-dependencies = [
- "toml_edit 0.23.7",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -3045,12 +2933,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -3206,15 +3088,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3282,35 +3155,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rkyv"
-version = "0.7.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
-dependencies = [
- "bitvec",
- "bytecheck",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "rpassword"
 version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3363,22 +3207,6 @@ checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
 dependencies = [
  "sha2 0.10.9",
  "walkdir",
-]
-
-[[package]]
-name = "rust_decimal"
-version = "1.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35affe401787a9bd846712274d97654355d21b2a2c092a3139aabe31e9022282"
-dependencies = [
- "arrayvec",
- "borsh",
- "bytes",
- "num-traits",
- "rand 0.8.5",
- "rkyv",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -3599,12 +3427,6 @@ dependencies = [
  "ring",
  "untrusted",
 ]
-
-[[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
@@ -3900,12 +3722,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4047,7 +3863,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml 0.8.23",
- "toml_edit 0.22.27",
+ "toml_edit",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -4532,7 +4348,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml 0.9.8",
- "toml_edit 0.22.27",
+ "toml_edit",
  "uuid",
  "walkdir",
  "webbrowser",
@@ -4545,7 +4361,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rust_decimal",
  "sha2 0.10.9",
  "soroban-sdk 23.0.2",
  "stellar-build",
@@ -4699,12 +4514,6 @@ dependencies = [
  "quote",
  "syn 2.0.110",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -4978,7 +4787,7 @@ dependencies = [
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
+ "toml_edit",
 ]
 
 [[package]]
@@ -5025,18 +4834,6 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.23.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
-dependencies = [
- "indexmap 2.12.0",
- "toml_datetime 0.7.3",
- "toml_parser",
  "winnow",
 ]
 
@@ -5959,15 +5756,6 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
 
 [[package]]
 name = "xattr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,6 +848,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67773048316103656a637612c4a62477603b777d91d9c62ff2290f9cde178fdb"
+dependencies = [
+ "ctor-proc-macro",
+ "dtor",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,6 +1153,21 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dtor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dyn-clone"
@@ -3842,11 +3873,11 @@ dependencies = [
  "sha2 0.10.9",
  "shell-escape",
  "shlex",
- "soroban-ledger-snapshot 23.1.0",
- "soroban-sdk 23.1.0",
- "soroban-spec 23.1.0",
+ "soroban-ledger-snapshot 23.2.1",
+ "soroban-sdk 23.2.1",
+ "soroban-spec 23.2.1",
  "soroban-spec-json",
- "soroban-spec-rust 23.1.0",
+ "soroban-spec-rust 23.2.1",
  "soroban-spec-tools",
  "soroban-spec-typescript",
  "stellar-asset-spec",
@@ -3971,9 +4002,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "23.1.0"
+version = "23.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004e0cdfd01c073e23d28813625bd77b9a6a0dc35c65920323e75450f1bfe400"
+checksum = "05774488b01f32ec69e2206d3306ea9178e0130d3e38263bf70208c7112e4d47"
 dependencies = [
  "serde",
  "serde_json",
@@ -3991,7 +4022,7 @@ dependencies = [
  "arbitrary",
  "bytes-lit",
  "crate-git-revision",
- "ctor",
+ "ctor 0.2.9",
  "derive_arbitrary",
  "ed25519-dalek",
  "rand 0.8.5",
@@ -4007,19 +4038,24 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "23.1.0"
+version = "23.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d605064e7c7c08474a750496b256d051ac568aa072254e3b77e080fab99e3fb7"
+checksum = "6bba6c9e79005a6fd5d4a2ee0a0b6df10994dfd6ec0783c2cbf5e4ba98bca034"
 dependencies = [
+ "arbitrary",
  "bytes-lit",
  "crate-git-revision",
+ "ctor 0.5.0",
+ "derive_arbitrary",
+ "ed25519-dalek",
  "rand 0.8.5",
  "rustc_version",
  "serde",
  "serde_json",
  "soroban-env-guest",
  "soroban-env-host",
- "soroban-sdk-macros 23.1.0",
+ "soroban-ledger-snapshot 23.2.1",
+ "soroban-sdk-macros 23.2.1",
  "stellar-strkey 0.0.13",
 ]
 
@@ -4044,9 +4080,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "23.1.0"
+version = "23.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611c1b3118d118852cb0b7c0e702b63dbb54de213d0ef9da354650786656b499"
+checksum = "9d550a4571f187e7b5f7cd1aaecfc0028d11b11fa14e19b75e312b62aa2b28ff"
 dependencies = [
  "darling 0.20.11",
  "heck 0.5.0",
@@ -4056,8 +4092,8 @@ dependencies = [
  "quote",
  "sha2 0.10.9",
  "soroban-env-common",
- "soroban-spec 23.1.0",
- "soroban-spec-rust 23.1.0",
+ "soroban-spec 23.2.1",
+ "soroban-spec-rust 23.2.1",
  "stellar-xdr",
  "syn 2.0.110",
 ]
@@ -4075,9 +4111,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "23.1.0"
+version = "23.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829e617c2a6e7293f31a9d8f74f543f102f57510fe13a1da38e37a0481fc2e88"
+checksum = "e56d9d9bb0380c78fbeb25b2335cfd868aff5c85b3e0e262966697c9af91844a"
 dependencies = [
  "base64 0.22.1",
  "stellar-xdr",
@@ -4095,7 +4131,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.9.9",
- "soroban-spec 23.1.0",
+ "soroban-spec 23.2.1",
  "stellar-xdr",
  "thiserror 1.0.69",
 ]
@@ -4117,15 +4153,15 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "23.1.0"
+version = "23.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a7f15c7e8fc5216df7e431d134e5298886d125b842fb0861b8f42095992a5c"
+checksum = "92174e24ad92aac4e2048fd1ad48131ffc3b50bc2bff33e7c9911c156de6bba6"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
  "sha2 0.10.9",
- "soroban-spec 23.1.0",
+ "soroban-spec 23.2.1",
  "stellar-xdr",
  "syn 2.0.110",
  "thiserror 1.0.69",
@@ -4133,16 +4169,16 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-tools"
-version = "23.1.4"
+version = "23.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f62b14878b51129b71c25ec047bb6c546c5985e3540cc4a315d111c248fb2a5c"
+checksum = "c0c93d36672b32a7d57719943a6883817cebdcea4c68478ce487084e9a13bd1e"
 dependencies = [
  "base64 0.21.7",
  "ethnum",
  "hex",
  "itertools 0.10.5",
  "serde_json",
- "soroban-spec 23.1.0",
+ "soroban-spec 23.2.1",
  "stellar-strkey 0.0.13",
  "stellar-xdr",
  "thiserror 1.0.69",
@@ -4164,7 +4200,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.9.9",
- "soroban-spec 23.1.0",
+ "soroban-spec 23.2.1",
  "stellar-xdr",
  "thiserror 1.0.69",
 ]
@@ -4175,7 +4211,7 @@ version = "23.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e1c8b03d3d9187c08d7e21ef2444a2e695e6339c7539af7230d0726cb945e39"
 dependencies = [
- "soroban-sdk 23.1.0",
+ "soroban-sdk 23.2.1",
 ]
 
 [[package]]
@@ -4184,7 +4220,7 @@ version = "23.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60497b6c7c7e4ea4fe3c34e0956f1f5e844b82b2db629c266ddc4cf6239fdcf0"
 dependencies = [
- "soroban-sdk 23.1.0",
+ "soroban-sdk 23.2.1",
  "soroban-token-sdk",
 ]
 
@@ -4235,7 +4271,7 @@ version = "23.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16215a995c89f2e4cdab0c64c9cde74c582894d3f446b3fb149278dff0535281"
 dependencies = [
- "soroban-sdk 23.1.0",
+ "soroban-sdk 23.2.1",
  "soroban-token-sdk",
  "soroban-token-spec",
 ]
@@ -4362,7 +4398,7 @@ dependencies = [
  "quote",
  "regex",
  "sha2 0.10.9",
- "soroban-sdk 23.0.2",
+ "soroban-sdk 23.2.1",
  "stellar-build",
  "stellar-strkey 0.0.13",
  "stellar-xdr",
@@ -4378,7 +4414,7 @@ dependencies = [
  "clap",
  "fs_extra",
  "soroban-cli",
- "soroban-sdk 23.0.2",
+ "soroban-sdk 23.2.1",
  "stellar-registry-cli",
  "stellar-scaffold-cli",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ stellar-registry = { path = "crates/stellar-registry" }
 
 stellar-cli = { version = "23.1.4", package = "soroban-cli", default-features = false  }
 soroban-rpc = { package = "stellar-rpc-client", version = "23.0.1" }
-soroban-spec-tools = "23.1.2"
+soroban-spec-tools = "23.2.1"
 
-soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "99134976ee1d31fa1fa5db8a63bd1ea66b8abda8" }
+soroban-sdk = {  version = "23.2.1" }
 admin-sep = { git = "https://github.com/theahaco/admin-sep", rev = "0a33529733d790aa6806e8210c30eba2a2b7dfb0" }
 stellar-xdr = "23.0.0"
 stellar-strkey = "0.0.13"

--- a/contracts/registry/Cargo.toml
+++ b/contracts/registry/Cargo.toml
@@ -13,12 +13,13 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { workspace = true, features = ["alloc"] }
-admin-sep = { workspace = true }
+soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "99134976ee1d31fa1fa5db8a63bd1ea66b8abda8" , features = ["alloc"] }
+admin-sep = { git = "https://github.com/theahaco/admin-sep", rev = "0a33529733d790aa6806e8210c30eba2a2b7dfb0" }
+
 semver = { version = "1.0.27", default-features = false }
 
 [dev-dependencies]
-soroban-sdk = { workspace = true, features = ["testutils"] }
+soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "99134976ee1d31fa1fa5db8a63bd1ea66b8abda8" ,  features = ["testutils"] }
 stellar-registry = { workspace = true }
 assert_matches = "1.5.0"
 stellar-xdr = { workspace = true }

--- a/contracts/test/hello_world/Cargo.toml
+++ b/contracts/test/hello_world/Cargo.toml
@@ -14,8 +14,8 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { workspace = true }
+soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "99134976ee1d31fa1fa5db8a63bd1ea66b8abda8" }
 admin-sep = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { workspace = true, features = ["testutils"] }
+soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "99134976ee1d31fa1fa5db8a63bd1ea66b8abda8", features = ["testutils"] }

--- a/contracts/test/hello_world_v2/Cargo.toml
+++ b/contracts/test/hello_world_v2/Cargo.toml
@@ -14,8 +14,8 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { workspace = true }
+soroban-sdk = {  git = "https://github.com/stellar/rs-soroban-sdk", rev = "99134976ee1d31fa1fa5db8a63bd1ea66b8abda8" }
 admin-sep = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { workspace = true, features = ["testutils"] }
+soroban-sdk = {  git = "https://github.com/stellar/rs-soroban-sdk", rev = "99134976ee1d31fa1fa5db8a63bd1ea66b8abda8", features = ["testutils"] }

--- a/contracts/test/hello_world_v3/Cargo.toml
+++ b/contracts/test/hello_world_v3/Cargo.toml
@@ -14,8 +14,8 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { workspace = true }
+soroban-sdk = {  git = "https://github.com/stellar/rs-soroban-sdk", rev = "99134976ee1d31fa1fa5db8a63bd1ea66b8abda8" }
 admin-sep = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { workspace = true, features = ["testutils"] }
+soroban-sdk = {  git = "https://github.com/stellar/rs-soroban-sdk", rev = "99134976ee1d31fa1fa5db8a63bd1ea66b8abda8", features = ["testutils"] }

--- a/crates/stellar-scaffold-macro/Cargo.toml
+++ b/crates/stellar-scaffold-macro/Cargo.toml
@@ -18,7 +18,6 @@ stellar-strkey = "0.0.13"
 regex = "1.12.2"
 stellar-xdr = "23.0.0"
 sha2 = "0.10.9"
-rust_decimal = "1.39.0"
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/crates/stellar-scaffold-macro/Cargo.toml
+++ b/crates/stellar-scaffold-macro/Cargo.toml
@@ -18,3 +18,7 @@ stellar-strkey = "0.0.13"
 regex = "1.12.2"
 stellar-xdr = "23.0.0"
 sha2 = "0.10.9"
+rust_decimal = "1.39.0"
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/crates/stellar-scaffold-macro/src/asset.rs
+++ b/crates/stellar-scaffold-macro/src/asset.rs
@@ -108,7 +108,7 @@ pub fn parse_literal(lit_str: &syn::LitStr) -> TokenStream {
                 soroban_sdk::token::TokenClient::new(&env, &contract_id(env))
             }
 
-            pub fn register(env: &soroban_sdk::Env, admin: &soroban_sdk::Address) {
+            pub fn register(env: &soroban_sdk::Env) {
                 let symbol = token_client(env).try_symbol();
                 if symbol.is_err()  {
                     env.deployer().with_stellar_asset(SERIALIZED_ASSET).deploy();
@@ -214,7 +214,7 @@ mod test {
                     soroban_sdk::token::TokenClient::new(&env, &contract_id(env))
                 }
 
-                pub fn register(env: &soroban_sdk::Env, admin: &soroban_sdk::Address) {
+                pub fn register(env: &soroban_sdk::Env) {
                     let symbol = token_client(env).try_symbol();
                     if symbol.is_err()  {
                         env.deployer().with_stellar_asset(SERIALIZED_ASSET).deploy();
@@ -296,7 +296,7 @@ mod test {
                     soroban_sdk::token::TokenClient::new(&env, &contract_id(env))
                 }
 
-                pub fn register(env: &soroban_sdk::Env, admin: &soroban_sdk::Address) {
+                pub fn register(env: &soroban_sdk::Env) {
                     let symbol = token_client(env).try_symbol();
                     if symbol.is_err()  {
                         env.deployer().with_stellar_asset(SERIALIZED_ASSET).deploy();

--- a/crates/stellar-scaffold-macro/src/asset.rs
+++ b/crates/stellar-scaffold-macro/src/asset.rs
@@ -55,6 +55,7 @@ pub fn parse_literal(lit_str: &syn::LitStr, network: &Network) -> TokenStream {
     // let contract_id = format_ident!("\"{contract_id}\"");
     let contract_id = contract_id.to_string();
     let mod_name = format_ident!("{code}");
+    let convert_name = format_ident!("{code}_to_min_unit");
     quote! {
         #[allow(non_upper_case_globals)]
         pub(crate) mod #mod_name {
@@ -70,6 +71,22 @@ pub fn parse_literal(lit_str: &syn::LitStr, network: &Network) -> TokenStream {
             /// Create a Stellar Asset Client for the asset which provides an admin interface
             pub fn token_client<'a>(env: &soroban_sdk::Env) -> soroban_sdk::token::TokenClient<'a> {
                 soroban_sdk::token::TokenClient::new(&env, &contract_id(env))
+            }
+
+            #[cfg(test)]
+            pub fn test_register(env: &soroban_sdk::Env, admin: &soroban_sdk::Address) -> soroban_sdk::testutils::StellarAssetContract {
+                let sac = env.register_stellar_asset_contract_v2(admin.clone());
+                stellar_asset_client(env).mint(admin, &1_000_000_000.to_i128().unwrap());
+                sac
+            }
+
+            #[cfg(not(test))]
+            pub fn register() {
+
+            }
+
+            pub fn #convert_name() {
+
             }
         }
     }

--- a/crates/stellar-scaffold-macro/src/asset.rs
+++ b/crates/stellar-scaffold-macro/src/asset.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
-use sha2::{Digest, Sha256};
+use std::io::Cursor;
+use std::str::FromStr;
 
-use stellar_build::Network;
 use stellar_xdr::curr as xdr;
 use xdr::WriteXdr;
 
@@ -14,10 +14,16 @@ pub fn parse_asset(str: &str) -> Result<(xdr::Asset, String), xdr::Error> {
     let split: Vec<&str> = str.splitn(2, ':').collect();
     assert!(split.len() == 2, "invalid asset \"{str}\"");
     let code = split[0];
-    let issuer: xdr::AccountId = split[1].parse()?;
+    let iss = split[1];
+
+    let issuer: xdr::AccountId = xdr::AccountId::from_str(iss)?;
     let re = regex::Regex::new("^[[:alnum:]]{1,12}$").expect("regex failed");
     assert!(re.is_match(code), "invalid asset \"{str}\"");
-    let asset_code: xdr::AssetCode = code.parse()?;
+    let asset_code = match code.len() {
+        4 => xdr::AssetCode::CreditAlphanum4(xdr::AssetCode4(code.as_bytes().try_into()?)),
+        12 => xdr::AssetCode::CreditAlphanum12(xdr::AssetCode12(code.as_bytes().try_into()?)),
+        _ => panic!("invalid asset code length"),
+    };
     Ok((
         match asset_code {
             xdr::AssetCode::CreditAlphanum4(asset_code) => {
@@ -31,39 +37,68 @@ pub fn parse_asset(str: &str) -> Result<(xdr::Asset, String), xdr::Error> {
     ))
 }
 
-pub fn generate_asset_id(
-    asset: &str,
-    network: &Network,
-) -> Result<(stellar_strkey::Contract, String), xdr::Error> {
-    let (asset, code) = parse_asset(asset).unwrap();
-    let network_id = xdr::Hash(network.id());
-    let preimage = xdr::HashIdPreimage::ContractId(xdr::HashIdPreimageContractId {
-        network_id,
-        contract_id_preimage: xdr::ContractIdPreimage::Asset(asset.clone()),
-    });
-    let preimage_xdr = preimage.to_xdr(xdr::Limits::none())?;
-    Ok((
-        stellar_strkey::Contract(Sha256::digest(preimage_xdr).into()),
-        code,
-    ))
+pub fn get_serialized_asset(asset: &str) -> Result<(String, Vec<u8>), xdr::Error> {
+    let (asset, code) = parse_asset(asset)?;
+
+    let mut data = Vec::new();
+    let cursor = Cursor::new(&mut data);
+    let mut limit = xdr::Limited::new(cursor, xdr::Limits::none());
+    asset.write_xdr(&mut limit)?;
+
+    Ok((code, data))
 }
 
 /// Generate the code to read the `STELLAR_NETWORK` environment variable
 /// and call the `generate_asset_id` function
-pub fn parse_literal(lit_str: &syn::LitStr, network: &Network) -> TokenStream {
-    let (contract_id, code) = generate_asset_id(&lit_str.value(), network).unwrap();
-    // let contract_id = format_ident!("\"{contract_id}\"");
-    let contract_id = contract_id.to_string();
+pub fn parse_literal(lit_str: &syn::LitStr) -> TokenStream {
+    let (code, data) = get_serialized_asset(&lit_str.value()).unwrap();
     let mod_name = format_ident!("{code}");
-    let convert_name = format_ident!("{code}_to_min_unit");
+    let test_mod_name = format_ident!("test_{code}");
+
+    let size = data.len();
+
     quote! {
+        #[allow(non_upper_case_globals)]
+        pub(crate) mod #test_mod_name {
+            use super::*;
+
+            /// Create a Stellar Asset Client for the asset which provides an admin interface
+            pub fn stellar_asset_client<'a>(env: &soroban_sdk::Env, sac:&soroban_sdk::testutils::StellarAssetContract) -> soroban_sdk::token::StellarAssetClient<'a> {
+                soroban_sdk::token::StellarAssetClient::new(&env, &sac.address())
+            }
+            /// Create a Stellar Asset Client for the asset which provides an admin interface
+            pub fn token_client<'a>(env: &soroban_sdk::Env, sac:&soroban_sdk::testutils::StellarAssetContract) -> soroban_sdk::token::TokenClient<'a> {
+                soroban_sdk::token::TokenClient::new(&env, &sac.address())
+            }
+
+            /// Registers a new SAC contract (to use in unit tests only)
+            pub fn register(env: &soroban_sdk::Env, admin: &soroban_sdk::Address) -> soroban_sdk::testutils::StellarAssetContract {
+                let sac = env.register_stellar_asset_contract_v2(admin.clone());
+                let cl = stellar_asset_client(env, &sac);
+                env.mock_all_auths();
+                cl.mint(admin, &1_000_000_000_i128);
+                sac
+            }
+
+            pub fn to_min_unit(float: f64) -> i128 {
+                return (float * 10_000_000_f64) as i128;
+            }
+
+            pub fn from_min_unit(num: i128) -> f64 {
+                return (num) as f64 / 10_000_000_f64;
+            }
+        }
+
         #[allow(non_upper_case_globals)]
         pub(crate) mod #mod_name {
             use super::*;
+            pub const SERIALIZED_ASSET: [u8; #size] = [ #(#data),* ];
+
             /// Contract id for the Stellar Asset Contract
             pub fn contract_id(env: &soroban_sdk::Env) -> soroban_sdk::Address {
-                soroban_sdk::Address::from_str(&env, #contract_id)
+                env.deployer().with_stellar_asset(SERIALIZED_ASSET).deployed_address()
             }
+
             /// Create a Stellar Asset Client for the asset which provides an admin interface
             pub fn stellar_asset_client<'a>(env: &soroban_sdk::Env) -> soroban_sdk::token::StellarAssetClient<'a> {
                 soroban_sdk::token::StellarAssetClient::new(&env, &contract_id(env))
@@ -73,20 +108,19 @@ pub fn parse_literal(lit_str: &syn::LitStr, network: &Network) -> TokenStream {
                 soroban_sdk::token::TokenClient::new(&env, &contract_id(env))
             }
 
-            #[cfg(test)]
-            pub fn test_register(env: &soroban_sdk::Env, admin: &soroban_sdk::Address) -> soroban_sdk::testutils::StellarAssetContract {
-                let sac = env.register_stellar_asset_contract_v2(admin.clone());
-                stellar_asset_client(env).mint(admin, &1_000_000_000.to_i128().unwrap());
-                sac
+            pub fn register(env: &soroban_sdk::Env, admin: &soroban_sdk::Address) {
+                let symbol = token_client(env).try_symbol();
+                if symbol.is_err()  {
+                    env.deployer().with_stellar_asset(SERIALIZED_ASSET).deploy();
+                }
             }
 
-            #[cfg(not(test))]
-            pub fn register() {
-
+            pub fn to_min_unit(float: f64) -> i128 {
+                return (float * 10_000_000_f64) as i128;
             }
 
-            pub fn #convert_name() {
-
+            pub fn from_min_unit(num: i128) -> f64 {
+                return (num) as f64 / 10_000_000_f64;
             }
         }
     }
@@ -95,13 +129,6 @@ pub fn parse_literal(lit_str: &syn::LitStr, network: &Network) -> TokenStream {
 #[cfg(test)]
 mod test {
     use super::*;
-    use Network::*;
-    const NETWORKS: [Network; 4] = [
-        Network::Local,
-        Network::Testnet,
-        Network::Futurenet,
-        Network::Mainnet,
-    ];
 
     const USDC: &str = "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
 
@@ -114,50 +141,70 @@ mod test {
         let (asset, code) = parse_asset("xlm").unwrap();
         assert_eq!(asset, xdr::Asset::Native);
         assert_eq!(code, "xlm");
-        for network in &NETWORKS {
-            match (
-                network,
-                generate_asset_id("native", network)
-                    .unwrap()
-                    .0
-                    .to_string()
-                    .as_str(),
-            ) {
-                (Local, "CDMLFMKMMD7MWZP3FKUBZPVHTUEDLSX4BYGYKH4GCESXYHS3IHQ4EIG4")
-                | (Testnet, "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC")
-                | (Futurenet, "CCLFEEF3IHRPZVGCYCRLKQNEXM5XM2BKENUHHXUL45Z4T5WRML3KB4SS")
-                | (Mainnet, "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA") => {}
-                (x, s) => panic!("Unexpected network {x:?} with asset {s}"),
-            }
-        }
+
+        assert_eq!(get_serialized_asset("native").unwrap().0, "native");
+        assert_eq!(get_serialized_asset("native").unwrap().1, [0, 0, 0, 0]);
     }
 
     // Test for parsing USDC token
     #[test]
     fn parse_usdc() {
-        for network in &NETWORKS {
-            let asset_id = generate_asset_id(USDC, network).unwrap().0;
-            match (network, asset_id.to_string().as_str()) {
-                (Local, "CB5SYISL2JCNQQRPFS5H4EFEESWUSNTDYMUNQX7TWZE45MYWYEYWCHAU")
-                | (Testnet, "CA2E53VHFZ6YSWQIEIPBXJQGT6VW3VKWWZO555XKRQXYJ63GEBJJGHY7")
-                | (Futurenet, "CAIGIAHVHIPSS2OAFGYBPKUG2DFU5AIFE5FZM24UBVCWFJIQZNYXKPE7")
-                | (Mainnet, "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75") => {}
-                (x, s) => panic!("Unexpected network {x:?} with asset {s}"),
-            }
-        }
+        assert_eq!(get_serialized_asset(USDC).unwrap().0, "USDC");
+        assert_eq!(
+            get_serialized_asset(USDC).unwrap().1,
+            [
+                0, 0, 0, 1, 85, 83, 68, 67, 0, 0, 0, 0, 59, 153, 17, 56, 14, 254, 152, 139, 160,
+                168, 144, 14, 177, 207, 228, 79, 54, 111, 125, 190, 148, 107, 237, 7, 114, 64, 247,
+                246, 36, 223, 21, 197
+            ]
+        );
     }
 
     #[test]
     fn native_client() {
         let lit: syn::LitStr = syn::parse_quote!("native");
         let expected = quote! {
-            #[allow (non_upper_case_globals)]
+            #[allow(non_upper_case_globals)]
+            pub(crate) mod test_native {
+                use super::*;
+
+                /// Create a Stellar Asset Client for the asset which provides an admin interface
+                pub fn stellar_asset_client<'a>(env: &soroban_sdk::Env, sac:&soroban_sdk::testutils::StellarAssetContract) -> soroban_sdk::token::StellarAssetClient<'a> {
+                    soroban_sdk::token::StellarAssetClient::new(&env, &sac.address())
+                }
+                /// Create a Stellar Asset Client for the asset which provides an admin interface
+                pub fn token_client<'a>(env: &soroban_sdk::Env, sac:&soroban_sdk::testutils::StellarAssetContract) -> soroban_sdk::token::TokenClient<'a> {
+                    soroban_sdk::token::TokenClient::new(&env, &sac.address())
+                }
+
+                /// Registers a new SAC contract (to use in unit tests only)
+                pub fn register(env: &soroban_sdk::Env, admin: &soroban_sdk::Address) -> soroban_sdk::testutils::StellarAssetContract {
+                    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+                    let cl = stellar_asset_client(env, &sac);
+                    env.mock_all_auths();
+                    cl.mint(admin, &1_000_000_000_i128);
+                    sac
+                }
+
+                pub fn to_min_unit(float: f64) -> i128 {
+                    return (float * 10_000_000_f64) as i128;
+                }
+
+                pub fn from_min_unit(num: i128) -> f64 {
+                    return (num) as f64 / 10_000_000_f64;
+                }
+            }
+
+            #[allow(non_upper_case_globals)]
             pub(crate) mod native {
                 use super::*;
+                pub const SERIALIZED_ASSET: [u8; 4usize] = [0u8 , 0u8 , 0u8 , 0u8];
+
                 /// Contract id for the Stellar Asset Contract
                 pub fn contract_id(env: &soroban_sdk::Env) -> soroban_sdk::Address {
-                    soroban_sdk::Address::from_str(&env, "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC")
+                    env.deployer().with_stellar_asset(SERIALIZED_ASSET).deployed_address()
                 }
+
                 /// Create a Stellar Asset Client for the asset which provides an admin interface
                 pub fn stellar_asset_client<'a>(env: &soroban_sdk::Env) -> soroban_sdk::token::StellarAssetClient<'a> {
                     soroban_sdk::token::StellarAssetClient::new(&env, &contract_id(env))
@@ -166,36 +213,32 @@ mod test {
                 pub fn token_client<'a>(env: &soroban_sdk::Env) -> soroban_sdk::token::TokenClient<'a> {
                     soroban_sdk::token::TokenClient::new(&env, &contract_id(env))
                 }
+
+                pub fn register(env: &soroban_sdk::Env, admin: &soroban_sdk::Address) {
+                    let symbol = token_client(env).try_symbol();
+                    if symbol.is_err()  {
+                        env.deployer().with_stellar_asset(SERIALIZED_ASSET).deploy();
+                    }
+                }
+
+                pub fn to_min_unit(float: f64) -> i128 {
+                    return (float * 10_000_000_f64) as i128;
+                }
+
+                pub fn from_min_unit(num: i128) -> f64 {
+                    return (num) as f64 / 10_000_000_f64;
+                }
             }
         };
-        let generated = parse_literal(&lit, &Network::Testnet);
+        let generated = parse_literal(&lit);
         assert_eq!(generated.to_string(), expected.to_string());
-    }
 
-    #[test]
-    fn xlm_client() {
         let lit: syn::LitStr = syn::parse_quote!("xlm");
-        let expected = quote! {
-            #[allow (non_upper_case_globals)]
-            pub(crate) mod xlm {
-                use super::*;
-                /// Contract id for the Stellar Asset Contract
-                pub fn contract_id(env: &soroban_sdk::Env) -> soroban_sdk::Address {
-                    soroban_sdk::Address::from_str(&env, "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC")
-                }
-                /// Create a Stellar Asset Client for the asset which provides an admin interface
-                pub fn stellar_asset_client<'a>(env: &soroban_sdk::Env) -> soroban_sdk::token::StellarAssetClient<'a> {
-                    soroban_sdk::token::StellarAssetClient::new(&env, &contract_id(env))
-                }
-                /// Create a Stellar Asset Client for the asset which provides an admin interface
-                pub fn token_client<'a>(env: &soroban_sdk::Env) -> soroban_sdk::token::TokenClient<'a> {
-                    soroban_sdk::token::TokenClient::new(&env, &contract_id(env))
-                }
-
-            }
-        };
-        let generated = parse_literal(&lit, &Network::Testnet);
-        assert_eq!(generated.to_string(), expected.to_string());
+        let generated = parse_literal(&lit);
+        assert_eq!(
+            generated.to_string(),
+            expected.to_string().replace("native", "xlm")
+        );
     }
 
     #[test]
@@ -203,13 +246,47 @@ mod test {
         let lit: syn::LitStr =
             syn::parse_quote!("USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN");
         let expected = quote! {
-            #[allow (non_upper_case_globals)]
+            #[allow(non_upper_case_globals)]
+            pub(crate) mod test_USDC {
+                use super::*;
+
+                /// Create a Stellar Asset Client for the asset which provides an admin interface
+                pub fn stellar_asset_client<'a>(env: &soroban_sdk::Env, sac:&soroban_sdk::testutils::StellarAssetContract) -> soroban_sdk::token::StellarAssetClient<'a> {
+                    soroban_sdk::token::StellarAssetClient::new(&env, &sac.address())
+                }
+                /// Create a Stellar Asset Client for the asset which provides an admin interface
+                pub fn token_client<'a>(env: &soroban_sdk::Env, sac:&soroban_sdk::testutils::StellarAssetContract) -> soroban_sdk::token::TokenClient<'a> {
+                    soroban_sdk::token::TokenClient::new(&env, &sac.address())
+                }
+
+                /// Registers a new SAC contract (to use in unit tests only)
+                pub fn register(env: &soroban_sdk::Env, admin: &soroban_sdk::Address) -> soroban_sdk::testutils::StellarAssetContract {
+                    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+                    let cl = stellar_asset_client(env, &sac);
+                    env.mock_all_auths();
+                    cl.mint(admin, &1_000_000_000_i128);
+                    sac
+                }
+
+                pub fn to_min_unit(float: f64) -> i128 {
+                    return (float * 10_000_000_f64) as i128;
+                }
+
+                pub fn from_min_unit(num: i128) -> f64 {
+                    return (num) as f64 / 10_000_000_f64;
+                }
+            }
+
+            #[allow(non_upper_case_globals)]
             pub(crate) mod USDC {
                 use super::*;
+                pub const SERIALIZED_ASSET: [u8 ; 44usize] = [0u8 , 0u8 , 0u8 , 1u8 , 85u8 , 83u8 , 68u8 , 67u8 , 0u8 , 0u8 , 0u8 , 0u8 , 59u8 , 153u8 , 17u8 , 56u8 , 14u8 , 254u8 , 152u8 , 139u8 , 160u8 , 168u8 , 144u8 , 14u8 , 177u8 , 207u8 , 228u8 , 79u8 , 54u8 , 111u8 , 125u8 , 190u8 , 148u8 , 107u8 , 237u8 , 7u8 , 114u8 , 64u8 , 247u8 , 246u8 , 36u8 , 223u8 , 21u8 , 197u8];
+
                 /// Contract id for the Stellar Asset Contract
                 pub fn contract_id(env: &soroban_sdk::Env) -> soroban_sdk::Address {
-                    soroban_sdk::Address::from_str(&env, "CA2E53VHFZ6YSWQIEIPBXJQGT6VW3VKWWZO555XKRQXYJ63GEBJJGHY7")
+                    env.deployer().with_stellar_asset(SERIALIZED_ASSET).deployed_address()
                 }
+
                 /// Create a Stellar Asset Client for the asset which provides an admin interface
                 pub fn stellar_asset_client<'a>(env: &soroban_sdk::Env) -> soroban_sdk::token::StellarAssetClient<'a> {
                     soroban_sdk::token::StellarAssetClient::new(&env, &contract_id(env))
@@ -219,9 +296,23 @@ mod test {
                     soroban_sdk::token::TokenClient::new(&env, &contract_id(env))
                 }
 
+                pub fn register(env: &soroban_sdk::Env, admin: &soroban_sdk::Address) {
+                    let symbol = token_client(env).try_symbol();
+                    if symbol.is_err()  {
+                        env.deployer().with_stellar_asset(SERIALIZED_ASSET).deploy();
+                    }
+                }
+
+                pub fn to_min_unit(float: f64) -> i128 {
+                    return (float * 10_000_000_f64) as i128;
+                }
+
+                pub fn from_min_unit(num: i128) -> f64 {
+                    return (num) as f64 / 10_000_000_f64;
+                }
             }
         };
-        let generated = parse_literal(&lit, &Network::Testnet);
+        let generated = parse_literal(&lit);
         assert_eq!(generated.to_string(), expected.to_string());
     }
 }

--- a/crates/stellar-scaffold-macro/src/lib.rs
+++ b/crates/stellar-scaffold-macro/src/lib.rs
@@ -3,7 +3,6 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 use quote::quote;
 use std::env;
-use stellar_build::Network;
 
 mod asset;
 
@@ -47,15 +46,32 @@ pub fn import_contract_client(tokens: TokenStream) -> TokenStream {
 }
 
 /// Generates a contract Client for a given asset.
+/// It produces 2 modules that can be used either in your contract code or in unit tests.
 /// As the first argument, it expects the name of an asset, e.g. "native" or "USDC:G1...."
 /// To generate the contract id for the asset, it uses the `STELLAR_NETWORK` environment variable,
 /// which could be either `local`, `testnet`, `futurenet` or `mainnet`. (uses `local` if not set)
 ///
+/// Example:
+/// ```ignore
+/// import_asset!("native");
+/// ```
+/// Can be used in unit tests as follows:
+/// ```ignore
+/// let env = &Env::default();
+/// let admin = &Address::generate(env);
+/// let sac = test_native::register(env, admin);
+/// let client = test_native::stellar_asset_client(env, &sac);
+/// assert_eq!(client.admin(), *admin);
+/// assert_eq!(client.balance(admin), 1000000000);
+/// ```
+/// And in your contract code:
+/// ```ignore
+/// ```
 /// # Panics
 ///
 #[proc_macro]
 pub fn import_asset(input: TokenStream) -> TokenStream {
     // Parse the input as a string literal
     let input_str = syn::parse_macro_input!(input as syn::LitStr);
-    asset::parse_literal(&input_str, &Network::passphrase_from_env()).into()
+    asset::parse_literal(&input_str).into()
 }

--- a/crates/stellar-scaffold-macro/src/lib.rs
+++ b/crates/stellar-scaffold-macro/src/lib.rs
@@ -47,7 +47,9 @@ pub fn import_contract_client(tokens: TokenStream) -> TokenStream {
 }
 
 /// Generates a contract Client for a given asset.
-/// It is expected that the name of an asset, e.g. "native" or "USDC:G1...."
+/// As the first argument, it expects the name of an asset, e.g. "native" or "USDC:G1...."
+/// To generate the contract id for the asset, it uses the `STELLAR_NETWORK` environment variable,
+/// which could be either `local`, `testnet`, `futurenet` or `mainnet`. (uses `local` if not set)
 ///
 /// # Panics
 ///

--- a/crates/stellar-scaffold-macro/tests/test.rs
+++ b/crates/stellar-scaffold-macro/tests/test.rs
@@ -1,0 +1,96 @@
+extern crate std;
+
+use std::io::Cursor;
+use std::str::FromStr;
+use rust_decimal::prelude::ToPrimitive;
+use soroban_sdk::{
+    self,
+     Address,
+    Env,
+};
+use stellar_xdr::curr as xdr;
+use stellar_xdr::curr::{WriteXdr};
+use stellar_scaffold_macro::import_asset;
+
+import_asset!("native");
+
+#[test]
+pub fn test_macro() {
+    let env = &Env::default();
+    let admin =&Address::from_str(env, "GC6RVI3M7DM5RFEZVBDLGOC4QJHEW66Q4TCTXGGLNCL7EXR5BM2VWJCG");
+    let bob = &Address::from_str(env, "GAMMPSGF3M62GCHVW4JKREODD7LZWQQ4Y7CURTR2M5SVEWOGYQ2XVFJU");
+    let addr = native::contract_id(env);
+    let _sac = native::stellar_asset_client(env);
+    let _client = native::token_client(env);
+
+    // Local network
+    assert_eq!(addr.to_string(), to_string(env, "CDMLFMKMMD7MWZP3FKUBZPVHTUEDLSX4BYGYKH4GCESXYHS3IHQ4EIG4"));
+
+    let asset = parse_asset("ASTT:GC6RVI3M7DM5RFEZVBDLGOC4QJHEW66Q4TCTXGGLNCL7EXR5BM2VWJCG");
+    let mut data = Vec::new();
+    let cursor = Cursor::new(&mut data);
+    let mut limit = xdr::Limited::new(cursor, xdr::Limits::none());
+    asset.unwrap().0.write_xdr(&mut limit).unwrap();
+
+    println!("{}", data.len());
+    let arr: [u8; 44] = data.try_into().unwrap();
+
+    let addr = env.deployer().with_stellar_asset(arr).deploy();
+
+    println!("{:?}", addr);
+
+    let sac = soroban_sdk::token::StellarAssetClient::new(&env, &addr);
+
+    assert_eq!(sac.symbol(), to_string(env,"ASTT"));
+    assert_eq!(sac.admin(), *admin);
+    env.mock_all_auths();
+    sac.mint(&bob, &1_000_000_000.to_i128().unwrap());
+    // println!("{}", sac.balance(bob));
+
+    // assert_eq!(client.symbol(), to_string(env,"XLM"));
+}
+
+// #[test]
+// pub fn foo () {
+//     let mut data = Vec::new();
+//     let cursor = Cursor::new(&mut data);
+//     let mut limit = Limited::new(cursor, Limits::none());
+//     let res = Asset::Native.write_xdr(&mut limit);
+//     println!("{:?}", res);
+//     println!("{:?}", data)
+// }
+
+pub fn to_string(env: &Env, s: &str) -> soroban_sdk::String {
+    soroban_sdk::String::from_str(env, s)
+}
+
+
+pub fn parse_asset(str: &str) -> Result<(xdr::Asset, String), xdr::Error> {
+    if str == "native" || str == "xlm" {
+        return Ok((xdr::Asset::Native, str.to_string()));
+    }
+    let split: Vec<&str> = str.splitn(2, ':').collect();
+    assert!(split.len() == 2, "invalid asset \"{str}\"");
+    let code = split[0];
+    let iss  = split[1];
+
+    let issuer: xdr::AccountId = xdr::AccountId::from_str(iss)?;
+    let re = regex::Regex::new("^[[:alnum:]]{1,12}$").expect("regex failed");
+    assert!(re.is_match(code), "invalid asset \"{str}\"");
+    let asset_code =  match code.len() {
+        4 => xdr::AssetCode::CreditAlphanum4(xdr::AssetCode4(code.as_bytes().try_into()?)),
+        12 => xdr::AssetCode::CreditAlphanum12(xdr::AssetCode12(code.as_bytes().try_into()?)),
+        _ => panic!("invalid asset code length"),
+    };
+    Ok((
+        match asset_code {
+            xdr::AssetCode::CreditAlphanum4(asset_code) => {
+                xdr::Asset::CreditAlphanum4(xdr::AlphaNum4 { asset_code, issuer })
+            }
+            xdr::AssetCode::CreditAlphanum12(asset_code) => {
+                xdr::Asset::CreditAlphanum12(xdr::AlphaNum12 { asset_code, issuer })
+            }
+        },
+        code.to_string(),
+    ))
+}

--- a/crates/stellar-scaffold-macro/tests/test.rs
+++ b/crates/stellar-scaffold-macro/tests/test.rs
@@ -1,96 +1,54 @@
 extern crate std;
 
-use std::io::Cursor;
-use std::str::FromStr;
-use rust_decimal::prelude::ToPrimitive;
-use soroban_sdk::{
-    self,
-     Address,
-    Env,
-};
-use stellar_xdr::curr as xdr;
-use stellar_xdr::curr::{WriteXdr};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{self, Address, Env};
 use stellar_scaffold_macro::import_asset;
 
 import_asset!("native");
 
 #[test]
-pub fn test_macro() {
+pub fn test_macro_native_production() {
     let env = &Env::default();
-    let admin =&Address::from_str(env, "GC6RVI3M7DM5RFEZVBDLGOC4QJHEW66Q4TCTXGGLNCL7EXR5BM2VWJCG");
-    let bob = &Address::from_str(env, "GAMMPSGF3M62GCHVW4JKREODD7LZWQQ4Y7CURTR2M5SVEWOGYQ2XVFJU");
-    let addr = native::contract_id(env);
-    let _sac = native::stellar_asset_client(env);
-    let _client = native::token_client(env);
+    let admin = &Address::from_str(
+        env,
+        "GC6RVI3M7DM5RFEZVBDLGOC4QJHEW66Q4TCTXGGLNCL7EXR5BM2VWJCG",
+    );
+    let symbol = native::token_client(env).try_symbol();
+    assert_eq!(symbol.is_err(), true);
+    native::register(env, admin);
 
-    // Local network
-    assert_eq!(addr.to_string(), to_string(env, "CDMLFMKMMD7MWZP3FKUBZPVHTUEDLSX4BYGYKH4GCESXYHS3IHQ4EIG4"));
+    let client = native::stellar_asset_client(env);
 
-    let asset = parse_asset("ASTT:GC6RVI3M7DM5RFEZVBDLGOC4QJHEW66Q4TCTXGGLNCL7EXR5BM2VWJCG");
-    let mut data = Vec::new();
-    let cursor = Cursor::new(&mut data);
-    let mut limit = xdr::Limited::new(cursor, xdr::Limits::none());
-    asset.unwrap().0.write_xdr(&mut limit).unwrap();
+    assert_eq!(
+        native::contract_id(env).to_string(),
+        to_string(
+            env,
+            "CB56OQJZFJXSSKFK3MXJZ4TLJAJFWH6KXN6BAWHQSJDZPHZFVBJ353HU"
+        )
+    );
+    assert_eq!(client.symbol(), to_string(env, "native"));
 
-    println!("{}", data.len());
-    let arr: [u8; 44] = data.try_into().unwrap();
+    // Check one more call is successful (does nothing)
+    native::register(env, admin);
 
-    let addr = env.deployer().with_stellar_asset(arr).deploy();
-
-    println!("{:?}", addr);
-
-    let sac = soroban_sdk::token::StellarAssetClient::new(&env, &addr);
-
-    assert_eq!(sac.symbol(), to_string(env,"ASTT"));
-    assert_eq!(sac.admin(), *admin);
-    env.mock_all_auths();
-    sac.mint(&bob, &1_000_000_000.to_i128().unwrap());
-    // println!("{}", sac.balance(bob));
-
-    // assert_eq!(client.symbol(), to_string(env,"XLM"));
+    assert_eq!(native::to_min_unit(1.0f64), 10000000);
+    assert_eq!(native::from_min_unit(10000000), 1.0f64);
 }
 
-// #[test]
-// pub fn foo () {
-//     let mut data = Vec::new();
-//     let cursor = Cursor::new(&mut data);
-//     let mut limit = Limited::new(cursor, Limits::none());
-//     let res = Asset::Native.write_xdr(&mut limit);
-//     println!("{:?}", res);
-//     println!("{:?}", data)
-// }
+#[test]
+pub fn test_native_unit_test() {
+    let env = &Env::default();
+    let admin = &Address::generate(env);
+    let sac = test_native::register(env, admin);
+    let client = test_native::stellar_asset_client(env, &sac);
+
+    assert_eq!(client.admin(), *admin);
+    assert_eq!(client.balance(admin), 1000000000);
+
+    assert_eq!(test_native::to_min_unit(1.0f64), 10000000);
+    assert_eq!(native::from_min_unit(10000000), 1.0f64);
+}
 
 pub fn to_string(env: &Env, s: &str) -> soroban_sdk::String {
     soroban_sdk::String::from_str(env, s)
-}
-
-
-pub fn parse_asset(str: &str) -> Result<(xdr::Asset, String), xdr::Error> {
-    if str == "native" || str == "xlm" {
-        return Ok((xdr::Asset::Native, str.to_string()));
-    }
-    let split: Vec<&str> = str.splitn(2, ':').collect();
-    assert!(split.len() == 2, "invalid asset \"{str}\"");
-    let code = split[0];
-    let iss  = split[1];
-
-    let issuer: xdr::AccountId = xdr::AccountId::from_str(iss)?;
-    let re = regex::Regex::new("^[[:alnum:]]{1,12}$").expect("regex failed");
-    assert!(re.is_match(code), "invalid asset \"{str}\"");
-    let asset_code =  match code.len() {
-        4 => xdr::AssetCode::CreditAlphanum4(xdr::AssetCode4(code.as_bytes().try_into()?)),
-        12 => xdr::AssetCode::CreditAlphanum12(xdr::AssetCode12(code.as_bytes().try_into()?)),
-        _ => panic!("invalid asset code length"),
-    };
-    Ok((
-        match asset_code {
-            xdr::AssetCode::CreditAlphanum4(asset_code) => {
-                xdr::Asset::CreditAlphanum4(xdr::AlphaNum4 { asset_code, issuer })
-            }
-            xdr::AssetCode::CreditAlphanum12(asset_code) => {
-                xdr::Asset::CreditAlphanum12(xdr::AlphaNum12 { asset_code, issuer })
-            }
-        },
-        code.to_string(),
-    ))
 }

--- a/crates/stellar-scaffold-macro/tests/test.rs
+++ b/crates/stellar-scaffold-macro/tests/test.rs
@@ -5,17 +5,14 @@ use soroban_sdk::{self, Address, Env};
 use stellar_scaffold_macro::import_asset;
 
 import_asset!("native");
+import_asset!("USDC:GC6RVI3M7DM5RFEZVBDLGOC4QJHEW66Q4TCTXGGLNCL7EXR5BM2VWJCG");
 
 #[test]
 pub fn test_macro_native_production() {
     let env = &Env::default();
-    let admin = &Address::from_str(
-        env,
-        "GC6RVI3M7DM5RFEZVBDLGOC4QJHEW66Q4TCTXGGLNCL7EXR5BM2VWJCG",
-    );
     let symbol = native::token_client(env).try_symbol();
     assert_eq!(symbol.is_err(), true);
-    native::register(env, admin);
+    native::register(env);
 
     let client = native::stellar_asset_client(env);
 
@@ -29,7 +26,7 @@ pub fn test_macro_native_production() {
     assert_eq!(client.symbol(), to_string(env, "native"));
 
     // Check one more call is successful (does nothing)
-    native::register(env, admin);
+    native::register(env);
 
     assert_eq!(native::to_min_unit(1.0f64), 10000000);
     assert_eq!(native::from_min_unit(10000000), 1.0f64);
@@ -47,6 +44,43 @@ pub fn test_native_unit_test() {
 
     assert_eq!(test_native::to_min_unit(1.0f64), 10000000);
     assert_eq!(native::from_min_unit(10000000), 1.0f64);
+}
+
+#[test]
+pub fn test_macro_usdc_production() {
+    let env = &Env::default();
+    let symbol = USDC::token_client(env).try_symbol();
+    assert_eq!(symbol.is_err(), true);
+    USDC::register(env);
+
+    let client = USDC::stellar_asset_client(env);
+
+    assert_eq!(
+        USDC::contract_id(env).to_string(),
+        to_string(
+            env,
+            "CAW2XLHJ6X4N2L343AJPVWL6DOI444B6TOHVCGHCOS4GF3TERVGTCAM7"
+        )
+    );
+    assert_eq!(client.symbol(), to_string(env, "USDC"));
+    assert_eq!(
+        client.admin().to_string(),
+        to_string(
+            env,
+            "GC6RVI3M7DM5RFEZVBDLGOC4QJHEW66Q4TCTXGGLNCL7EXR5BM2VWJCG"
+        )
+    );
+}
+
+#[test]
+pub fn test_usdc_unit_test() {
+    let env = &Env::default();
+    let admin = &Address::generate(env);
+    let sac = test_USDC::register(env, admin);
+    let client = test_USDC::stellar_asset_client(env, &sac);
+
+    assert_eq!(client.admin(), *admin);
+    assert_eq!(client.balance(admin), 1000000000);
 }
 
 pub fn to_string(env: &Env, s: &str) -> soroban_sdk::String {

--- a/crates/stellar-scaffold-test/fixtures/contracts/hello_v1/Cargo.toml
+++ b/crates/stellar-scaffold-test/fixtures/contracts/hello_v1/Cargo.toml
@@ -14,8 +14,8 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { workspace = true }
+soroban-sdk = {  git = "https://github.com/stellar/rs-soroban-sdk", rev = "99134976ee1d31fa1fa5db8a63bd1ea66b8abda8" }
 admin-sep = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { workspace = true, features = ["testutils"] }
+soroban-sdk = {  git = "https://github.com/stellar/rs-soroban-sdk", rev = "99134976ee1d31fa1fa5db8a63bd1ea66b8abda8", features = ["testutils"] }

--- a/crates/stellar-scaffold-test/fixtures/contracts/hello_v2/Cargo.toml
+++ b/crates/stellar-scaffold-test/fixtures/contracts/hello_v2/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { workspace = true }
+soroban-sdk = {  git = "https://github.com/stellar/rs-soroban-sdk", rev = "99134976ee1d31fa1fa5db8a63bd1ea66b8abda8" }
 admin-sep = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { workspace = true, features = ["testutils"] }
+soroban-sdk = {  git = "https://github.com/stellar/rs-soroban-sdk", rev = "99134976ee1d31fa1fa5db8a63bd1ea66b8abda8", features = ["testutils"] }


### PR DESCRIPTION
This PR reworks asset marco to match POC from @willemneal work done [here](https://github.com/theahaco/scaffold-stellar-frontend/blob/main/contracts/guess-the-number/src/xlm.rs)

It introduces 2 mods, 1 for unit testing, the other for actual "production" code (basically any env that is not a mock one. For example, can be used in contracts)

The unit testing mod is largely the same as the snapshot above (simply deploys new SAC and uses its instance to get clients). Useful to mock actual SACs in tests. (e.g. for XLM or any other asset).

The production mod deploys an actual SAC contract (if needed) and gets SAC contract ID using generated serialized asset (from the asset code). There are limitations on "production" mod for unit tests, so it's largely unusable, unfortunately (can't establish trustlines, can't mint)