### PR TITLE
Fix registry wasm name not being canonicalized

### DIFF
--- a/contracts/registry/src/registry/contract.rs
+++ b/contracts/registry/src/registry/contract.rs
@@ -71,6 +71,7 @@ impl Deployable for Contract {
         init: Option<soroban_sdk::Vec<soroban_sdk::Val>>,
     ) -> Result<Address, Error> {
         let contract_name = canonicalize(&contract_name)?;
+        let wasm_name = canonicalize(&wasm_name)?;
         let mut contract_map = Storage::new(env).contract;
         if contract_map.has(&contract_name) {
             return Err(Error::AlreadyDeployed);

--- a/contracts/registry/src/test.rs
+++ b/contracts/registry/src/test.rs
@@ -116,8 +116,8 @@ fn hello_world_using_publish_hash() {
 
     let version = registry.default_version();
 
-    let name = &to_string(env, "contract");
-    let wasm_name = &to_string(env, "wasm");
+    let name = &to_string(env, "contract_name");
+    let wasm_name = &to_string(env, "wasm_name");
 
     let author = &Address::generate(env);
 


### PR DESCRIPTION
Small bug fix. This was previously leading to contract not being found on calling `deploy` with names like "my_contract" (e.g. when you `publish` contract with name "my_contract", and then try to `deploy` it, not found error is returned, because `publish` canonicalize the name, while `deploy` did not)