### PR TITLE
WIP: fetch the most recent supported oz release

### DIFF
--- a/crates/stellar-scaffold-cli/src/commands/generate/contract/mod.rs
+++ b/crates/stellar-scaffold-cli/src/commands/generate/contract/mod.rs
@@ -262,7 +262,7 @@ members = []
 
     async fn fetch_latest_release() -> Result<Release, Error> {
         Self::fetch_latest_release_from_url(
-            "https://api.github.com/repos/OpenZeppelin/stellar-contracts/releases/latest",
+            "https://api.github.com/repos/OpenZeppelin/stellar-contracts/releases/tags/v0.5.1",
         )
         .await
     }


### PR DESCRIPTION
https://github.com/theahaco/scaffold-stellar/issues/356

The main issue with ^ is that the oz/stellar-contracts repo was updated and this repo has not yet been updated, to use newer versions of the soroban-sdk. 

We should upgrade the soroban-sdk version here, but I also want to find a way to have scaffold embed its most recent version of oz/stellar-contracts that it supports, so that we don't have to be perfectly in-sync with the oz release schedule. 

This is a first attempt - to have `generate` fetch a pinned release of oz/stellar-contract.
* upside(s)
        * small change
        * easy to see what is happening
* downside(s)
        * error prone - this would probably be easy to forget to update when upgrading other deps since it's not in Cargo.toml

Alternatives: 
* https://github.com/theahaco/scaffold-stellar/pull/358
* adds one of the libs that https://github.com/OpenZeppelin/stellar-contracts exports so we can fetch it's version and use that as our "latest oz version we support". 
* one upside to this is that we have cargo help us detect if we have incompatible versions of the oz contracts & soroban-sdk, etc.