### PR TITLE
Feat/ci to check oz contracts version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,13 @@ updates:
         update-types:
           - minor
           - patch
+
+  - package-ecosystem: "cargo"
+    directory: "/stellar-scaffold-test/fixtures/soroban-init-boilerplate"
+    schedule:
+      interval: "weekly"
+    groups:
+      cargo-minor:
+        update-types:
+          - minor
+          - patch

--- a/crates/stellar-scaffold-cli/src/commands/generate/contract/mod.rs
+++ b/crates/stellar-scaffold-cli/src/commands/generate/contract/mod.rs
@@ -123,8 +123,8 @@ impl Cmd {
 
         let examples_info = self.ensure_cache_updated(&printer).await?;
 
-        if example_name.starts_with(OZ_PREFIX) {
-            let (_, example_name) = example_name.split_at(3);
+        if let Some(rest) = example_name.strip_prefix(OZ_PREFIX) {
+            let example_name = rest;
             let dest_path = self
                 .output
                 .clone()
@@ -137,8 +137,8 @@ impl Cmd {
                 global_args,
                 printer,
             )
-        } else if example_name.starts_with(STELLAR_PREFIX) {
-            let (_, example_name) = example_name.split_at(8);
+        } else if let Some(rest) = example_name.strip_prefix(STELLAR_PREFIX) {
+            let example_name = rest;
             let dest_path = self
                 .output
                 .clone()

--- a/crates/stellar-scaffold-cli/src/commands/generate/contract/mod.rs
+++ b/crates/stellar-scaffold-cli/src/commands/generate/contract/mod.rs
@@ -625,19 +625,11 @@ members = []
         Ok(())
     }
 
-    async fn fetch_latest_supported_oz_release(printer: &Print) -> Result<Release, Error> {
-        // async fn fetch_latest_oz_release() -> Result<Release, Error> {
-        let version_override = std::env::var("OZ_RELEASE_TAG");
-        let version = match version_override {
-            Ok(v) => {
-                printer.warnln(format!(
-                    "Overriding OpenZeppelin Example Contracts Version to {v}"
-                ));
-                v
-            }
-            Err(_) => LATEST_SUPPORTED_OZ_RELEASE.to_owned(),
-        };
-        Self::fetch_latest_release_from_url(&format!("{OZ_EXAMPLES_GITHUB_API}{version}")).await
+    async fn fetch_latest_supported_oz_release() -> Result<Release, Error> {
+        Self::fetch_latest_release_from_url(&format!(
+            "{OZ_EXAMPLES_GITHUB_API}{LATEST_SUPPORTED_OZ_RELEASE}"
+        ))
+        .await
     }
 
     async fn fetch_latest_soroban_examples_release() -> Result<Release, Error> {
@@ -807,7 +799,7 @@ members = []
         let oz_cache_path = cli_cache_path.join("openzeppelin-stellar-contracts");
         let soroban_examples_cache_path = cli_cache_path.join("soroban_examples");
 
-        Self::update_cache(&oz_cache_path, &soroban_examples_cache_path, printer)
+        Self::update_cache(&oz_cache_path, &soroban_examples_cache_path)
             .await
             .or_else(|e| {
                 printer.warnln(format!("Failed to update examples cache: {e}"));
@@ -818,10 +810,9 @@ members = []
     async fn update_cache(
         oz_cache_path: &Path,
         soroban_examples_cache_path: &Path,
-        printer: &Print,
     ) -> Result<ExamplesInfo, Error> {
         // Get the latest supported oz release tag
-        let Release { tag_name } = Self::fetch_latest_supported_oz_release(printer).await?;
+        let Release { tag_name } = Self::fetch_latest_supported_oz_release().await?;
         let oz_repo_cache_path = oz_cache_path.join(&tag_name);
         if !oz_repo_cache_path.exists() {
             Self::cache_oz_repository(&oz_repo_cache_path, &tag_name).await?;

--- a/crates/stellar-scaffold-cli/src/commands/generate/contract/mod.rs
+++ b/crates/stellar-scaffold-cli/src/commands/generate/contract/mod.rs
@@ -20,8 +20,13 @@ use toml::Value::Table;
 
 const SOROBAN_EXAMPLES_REPO: &str = "https://github.com/stellar/soroban-examples";
 const STELLAR_PREFIX: &str = "stellar/";
+const SOROBAN_EXAMPLES_GITHUB_API: &str =
+    "https://api.github.com/repos/stellar/soroban-examples/releases/";
 const OZ_EXAMPLES_REPO: &str = "https://github.com/OpenZeppelin/stellar-contracts/examples";
 const OZ_PREFIX: &str = "oz/";
+const OZ_EXAMPLES_GITHUB_API: &str =
+    "https://api.github.com/repos/OpenZeppelin/stellar-contracts/releases/tags/";
+const LATEST_SUPPORTED_OZ_RELEASE: &str = "v0.5.1";
 
 #[derive(Deserialize)]
 struct Release {
@@ -583,7 +588,6 @@ members = []
         let printer = Print::new(global_args.quiet);
 
         let examples_info = self.ensure_cache_updated(&printer).await?;
-
         printer.infoln("Fetching available contract examples...");
 
         let oz_examples_path = examples_info.oz_examples_path.join("examples");
@@ -593,14 +597,19 @@ members = []
 
         printer.println("\nAvailable contract examples:");
         printer.println("────────────────────────────────");
-        printer.println(format!("From {SOROBAN_EXAMPLES_REPO}:"));
+        printer.println("From soroban-examples");
+
+        printer.println(format!("Source: {SOROBAN_EXAMPLES_REPO}"));
+        printer.println(format!("Version: {}", examples_info.soroban_version_tag));
 
         for example in &soroban_examples {
             printer.println(format!("  📁 {STELLAR_PREFIX}{example}"));
         }
 
         printer.println("────────────────────────────────");
-        printer.println(format!("From {OZ_EXAMPLES_REPO}"));
+        printer.println("From OpenZeppelin");
+        printer.println(format!("Source: {OZ_EXAMPLES_REPO}"));
+        printer.println(format!("Version: {}", examples_info.oz_version_tag));
 
         for example in &oz_examples {
             printer.println(format!("  📁 {OZ_PREFIX}{example}"));
@@ -616,18 +625,24 @@ members = []
         Ok(())
     }
 
-    async fn fetch_latest_oz_release() -> Result<Release, Error> {
-        Self::fetch_latest_release_from_url(
-            "https://api.github.com/repos/OpenZeppelin/stellar-contracts/releases/tags/v0.5.1",
-        )
-        .await
+    async fn fetch_latest_supported_oz_release(printer: &Print) -> Result<Release, Error> {
+        // async fn fetch_latest_oz_release() -> Result<Release, Error> {
+        let version_override = std::env::var("OZ_RELEASE_TAG");
+        let version = match version_override {
+            Ok(v) => {
+                printer.warnln(format!(
+                    "Overriding OpenZeppelin Example Contracts Version to {v}"
+                ));
+                v
+            }
+            Err(_) => LATEST_SUPPORTED_OZ_RELEASE.to_owned(),
+        };
+        Self::fetch_latest_release_from_url(&format!("{OZ_EXAMPLES_GITHUB_API}{version}")).await
     }
 
     async fn fetch_latest_soroban_examples_release() -> Result<Release, Error> {
-        Self::fetch_latest_release_from_url(
-            "https://api.github.com/repos/stellar/soroban-examples/releases/latest",
-        )
-        .await
+        Self::fetch_latest_release_from_url(&format!("{}{}", SOROBAN_EXAMPLES_GITHUB_API, "latest"))
+            .await
     }
 
     async fn fetch_latest_release_from_url(url: &str) -> Result<Release, Error> {
@@ -792,7 +807,7 @@ members = []
         let oz_cache_path = cli_cache_path.join("openzeppelin-stellar-contracts");
         let soroban_examples_cache_path = cli_cache_path.join("soroban_examples");
 
-        Self::update_cache(&oz_cache_path, &soroban_examples_cache_path)
+        Self::update_cache(&oz_cache_path, &soroban_examples_cache_path, printer)
             .await
             .or_else(|e| {
                 printer.warnln(format!("Failed to update examples cache: {e}"));
@@ -803,15 +818,17 @@ members = []
     async fn update_cache(
         oz_cache_path: &Path,
         soroban_examples_cache_path: &Path,
+        printer: &Print,
     ) -> Result<ExamplesInfo, Error> {
-        // Get the latest release tag
-        let Release { tag_name } = Self::fetch_latest_oz_release().await?;
+        // Get the latest supported oz release tag
+        let Release { tag_name } = Self::fetch_latest_supported_oz_release(printer).await?;
         let oz_repo_cache_path = oz_cache_path.join(&tag_name);
         if !oz_repo_cache_path.exists() {
             Self::cache_oz_repository(&oz_repo_cache_path, &tag_name).await?;
         }
         let oz_tag_name = tag_name;
 
+        // Get the latest soroban-examples release tag
         let Release { tag_name } = Self::fetch_latest_soroban_examples_release().await?;
         let soroban_examples_cache_path = soroban_examples_cache_path.join(&tag_name);
         if !soroban_examples_cache_path.exists() {

--- a/crates/stellar-scaffold-cli/src/commands/init.rs
+++ b/crates/stellar-scaffold-cli/src/commands/init.rs
@@ -168,7 +168,7 @@ impl Cmd {
         global_args: &global::Args,
     ) -> Result<(), Error> {
         let mut example_path = example_name;
-        if example_name.starts_with("oz-") {
+        if example_name.starts_with("oz/") {
             (_, example_path) = example_name.split_at(3);
         }
 

--- a/crates/stellar-scaffold-cli/src/commands/init.rs
+++ b/crates/stellar-scaffold-cli/src/commands/init.rs
@@ -168,10 +168,9 @@ impl Cmd {
         global_args: &global::Args,
     ) -> Result<(), Error> {
         let mut example_path = example_name;
-        if example_name.starts_with("oz/") {
-            (_, example_path) = example_name.split_at(3);
+        if let Some(rest) = example_name.strip_prefix("oz/") {
+            example_path = rest;
         }
-
         let printer = Print::new(global_args.quiet);
         let original_dir = env::current_dir()?;
         env::set_current_dir(absolute_project_path)?;

--- a/crates/stellar-scaffold-cli/src/commands/init.rs
+++ b/crates/stellar-scaffold-cli/src/commands/init.rs
@@ -108,7 +108,7 @@ impl Cmd {
 
         // Update the project's OpenZeppelin examples with the latest editions
         if !self.vers.tutorial {
-            let example_contracts = ["oz-nft-enumerable", "oz-fungible-allowlist"];
+            let example_contracts = ["oz/nft-enumerable", "oz/fungible-allowlist"];
 
             for contract in example_contracts {
                 self.update_oz_example(&absolute_project_path, contract, global_args)

--- a/crates/stellar-scaffold-cli/tests/it/build_clients/examples.rs
+++ b/crates/stellar-scaffold-cli/tests/it/build_clients/examples.rs
@@ -143,7 +143,7 @@ soroban_token_contract.client = false
 
 // this test makes sure that the OZ example repo release version that is included in new scaffold projects from the FE template is compatible with the current scaffold binary
 #[tokio::test]
-async fn test_scaffold_project_is_compatible_with_oz_examples(#[case] input: &str) {
+async fn test_scaffold_project_is_compatible_with_oz_examples() {
     TestEnv::from_init("test-project", |env| async move {
         env.set_environments_toml(format!(
             r#"
@@ -172,7 +172,7 @@ soroban_token_contract.client = false
             env.scaffold("generate")
                 .arg("contract")
                 .arg("--from")
-                .arg(input)
+                .arg(example)
                 .assert()
                 .success()
                 .stdout_as_str();

--- a/crates/stellar-scaffold-cli/tests/it/build_clients/examples.rs
+++ b/crates/stellar-scaffold-cli/tests/it/build_clients/examples.rs
@@ -78,27 +78,24 @@ soroban_token_contract.client = false
 #[case::oz_fungible_allowlist("oz/fungible-allowlist")]
 #[case::oz_fungible_blocklist("oz/fungible-blocklist")]
 #[case::oz_fungible_capped("oz/fungible-capped")]
-// the following are commented out because they currently do not build from a freshly created project
-// this is because we need to add a few deps to the FE template that's being used
-// stellar-contract-utils, etc
-// i also wonder if instead of updating the soroban-boilterplate-init we should use the FE template direclty to really test things properly
-
-//  #[case::oz_fungible_merkle_airdrop("oz/fungible-merkle-airdrop")]❌
-//  #[case::oz_fungible_pausable("oz/fungible-pausable")] ❌
+#[case::oz_fungible_pausable("oz/fungible-pausable")] 
 #[case::oz_fungible_vault("oz/fungible-vault")]
-//  #[case::oz_merkle_voting("oz/merkle-voting")]❌
-//  #[case::oz_multisig("oz/multisig")] ❌ ?
+#[case::oz_merkle_voting("oz/merkle-voting")]
 #[case::oz_nft_access_control("oz/nft-access-control")]
 #[case::oz_nft_consecutive("oz/nft-consecutive")]
 #[case::oz_nft_enumberable("oz/nft-enumerable")]
 #[case::oz_nft_royalties("oz/nft-royalties")]
 #[case::oz_nft_sequential_minting("oz/nft-sequential-minting")]
 #[case::oz_ownable("oz/ownable")]
-//  #[case::oz_pausable("oz/pausable")] ❌
-//  #[case::oz_rwa("oz/rwa")] ❌
-//  #[case::oz_sac_admin_generic("oz/sac-admin-generic")] ❌
+#[case::oz_pausable("oz/pausable")]
 #[case::oz_sac_admin_wrapper("oz/sac-admin-wrapper")]
-//  #[case::oz_upgradeable("oz/upgradeable")] ❌
+
+// the following are commented out because they currently do not build from a freshly created scaffold project
+// #[case::oz_fungible_merkle_airdrop("oz/fungible-merkle-airdrop")] // also needs hex-literal as a workspace dev dependency
+// #[case::oz_multisig("oz/multisig")] - doesn't have a cargo.toml in the root of the example 
+// #[case::oz_upgradeable("oz/upgradeable")] - doesn't have a cargo.toml in the root of the example
+// #[case::oz_rwa("oz/rwa")] - error: symbol `__constructor` is already defined
+// #[case::oz_sac_admin_generic("oz/sac-admin-generic")] ❌ also needs workspace.dependencies.ed25519-dalek
 
 fn test_adding_and_building_oz_examples(#[case] input: &str) {
     TestEnv::from("soroban-init-boilerplate", |env| {

--- a/crates/stellar-scaffold-cli/tests/it/build_clients/examples.rs
+++ b/crates/stellar-scaffold-cli/tests/it/build_clients/examples.rs
@@ -210,7 +210,7 @@ soroban_token_contract.client = false
         for example in vec![
             "oz/fungible-allowlist",
             "oz/fungible-capped",
-            "oz/fungible-pausible",
+            "oz/fungible-pausable",
         ] {
             env.scaffold("generate")
                 .arg("contract")

--- a/crates/stellar-scaffold-cli/tests/it/build_clients/examples.rs
+++ b/crates/stellar-scaffold-cli/tests/it/build_clients/examples.rs
@@ -76,8 +76,6 @@ soroban_token_contract.client = false
 
 // the following are commented out because they currently do not build from a freshly created scaffold project
 // #[case::oz_fungible_merkle_airdrop("oz/fungible-merkle-airdrop")] // also needs hex-literal as a workspace dev dependency
-// #[case::oz_multisig("oz/multisig")] - doesn't have a cargo.toml in the root of the example
-// #[case::oz_upgradeable("oz/upgradeable")] - doesn't have a cargo.toml in the root of the example
 // #[case::oz_rwa("oz/rwa")] - error: symbol `__constructor` is already defined
 // #[case::oz_sac_admin_generic("oz/sac-admin-generic")] - also needs workspace.dependencies.ed25519-dalek
 
@@ -138,6 +136,51 @@ soroban_token_contract.client = false
 
         // Run scaffold_build and assert success
         env.scaffold_build("development", true).assert().success();
+    });
+}
+
+#[rstest]
+#[case::oz_multisig("oz/multisig")]
+#[case::oz_upgradeable("oz/upgradeable")]
+fn test_adding_and_building_oz_examples_without_manifest_file_at_root(#[case] input: &str) {
+    TestEnv::from("soroban-init-boilerplate", |env| {
+        env.set_environments_toml(format!(
+            r#"
+[development]
+network = {{ rpc-url = "{}", network-passphrase = "Standalone Network ; February 2017" }}
+
+accounts = [
+    "alice",
+]
+[development.contracts]
+soroban_hello_world_contract.client = false
+soroban_increment_contract.client = false
+soroban_custom_types_contract.client = false
+soroban_auth_contract.client = false
+soroban_token_contract.client = false
+"#,
+            rpc_url()
+        ));
+        assert!(
+            env.cwd.join("contracts").is_dir(),
+            "no contracts directory found"
+        );
+        fs_extra::dir::remove(env.cwd.join("contracts"))
+            .expect("failed to remove contracts directory");
+
+        let output = env
+            .scaffold("generate")
+            .arg("contract")
+            .arg("--from")
+            .arg(input)
+            .arg("--output")
+            .arg(format!("{}/contracts/example", env.cwd.display()))
+            .assert()
+            .success()
+            .stderr_as_str();
+
+        println!("output {:?}", output);
+        assert!(output.contains("Warning: No workspace Cargo.toml found in current directory."));
     });
 }
 

--- a/crates/stellar-scaffold-cli/tests/it/build_clients/examples.rs
+++ b/crates/stellar-scaffold-cli/tests/it/build_clients/examples.rs
@@ -29,7 +29,78 @@ use stellar_scaffold_test::{AssertExt, TestEnv, rpc_url};
 #[case::timelock("stellar/timelock")]
 #[case::token("stellar/token")]
 #[case::ttl("stellar/ttl")]
-fn test_adding_and_building_example_work(#[case] input: &str) {
+fn test_adding_and_building_soroban_examples(#[case] input: &str) {
+    TestEnv::from("soroban-init-boilerplate", |env| {
+        env.set_environments_toml(format!(
+            r#"
+[development]
+network = {{ rpc-url = "{}", network-passphrase = "Standalone Network ; February 2017" }}
+
+accounts = [
+    "alice",
+]
+[development.contracts]
+soroban_hello_world_contract.client = false
+soroban_increment_contract.client = false
+soroban_custom_types_contract.client = false
+soroban_auth_contract.client = false
+soroban_token_contract.client = false
+"#,
+            rpc_url()
+        ));
+
+        println!("starting test in directory {:?}", env.cwd);
+        eprintln!("test directory {:?}", env.cwd);
+
+        assert!(
+            env.cwd.join("contracts").is_dir(),
+            "no contracts directory found"
+        );
+        fs_extra::dir::remove(env.cwd.join("contracts"))
+            .expect("failed to remove contracts directory");
+
+        env.scaffold("generate")
+            .arg("contract")
+            .arg("--from")
+            .arg(input)
+            .arg("--output")
+            .arg(format!("{}/contracts/example", env.cwd.display()))
+            .assert()
+            .success()
+            .stdout_as_str();
+
+        // Run scaffold_build and assert success
+        env.scaffold_build("development", true).assert().success();
+    });
+}
+
+#[rstest]
+#[case::oz_fungible_allowlist("oz/fungible-allowlist")]
+#[case::oz_fungible_blocklist("oz/fungible-blocklist")]
+#[case::oz_fungible_capped("oz/fungible-capped")]
+// the following are commented out because they currently do not build from a freshly created project
+// this is because we need to add a few deps to the FE template that's being used
+// stellar-contract-utils, etc
+// i also wonder if instead of updating the soroban-boilterplate-init we should use the FE template direclty to really test things properly
+
+//  #[case::oz_fungible_merkle_airdrop("oz/fungible-merkle-airdrop")]❌
+//  #[case::oz_fungible_pausable("oz/fungible-pausable")] ❌
+#[case::oz_fungible_vault("oz/fungible-vault")]
+//  #[case::oz_merkle_voting("oz/merkle-voting")]❌
+//  #[case::oz_multisig("oz/multisig")] ❌ ?
+#[case::oz_nft_access_control("oz/nft-access-control")]
+#[case::oz_nft_consecutive("oz/nft-consecutive")]
+#[case::oz_nft_enumberable("oz/nft-enumerable")]
+#[case::oz_nft_royalties("oz/nft-royalties")]
+#[case::oz_nft_sequential_minting("oz/nft-sequential-minting")]
+#[case::oz_ownable("oz/ownable")]
+//  #[case::oz_pausable("oz/pausable")] ❌
+//  #[case::oz_rwa("oz/rwa")] ❌
+//  #[case::oz_sac_admin_generic("oz/sac-admin-generic")] ❌
+#[case::oz_sac_admin_wrapper("oz/sac-admin-wrapper")]
+//  #[case::oz_upgradeable("oz/upgradeable")] ❌
+
+fn test_adding_and_building_oz_examples(#[case] input: &str) {
     TestEnv::from("soroban-init-boilerplate", |env| {
         env.set_environments_toml(format!(
             r#"

--- a/crates/stellar-scaffold-cli/tests/it/build_clients/examples.rs
+++ b/crates/stellar-scaffold-cli/tests/it/build_clients/examples.rs
@@ -74,11 +74,18 @@ soroban_token_contract.client = false
     });
 }
 
+// the following are commented out because they currently do not build from a freshly created scaffold project
+// #[case::oz_fungible_merkle_airdrop("oz/fungible-merkle-airdrop")] // also needs hex-literal as a workspace dev dependency
+// #[case::oz_multisig("oz/multisig")] - doesn't have a cargo.toml in the root of the example
+// #[case::oz_upgradeable("oz/upgradeable")] - doesn't have a cargo.toml in the root of the example
+// #[case::oz_rwa("oz/rwa")] - error: symbol `__constructor` is already defined
+// #[case::oz_sac_admin_generic("oz/sac-admin-generic")] - also needs workspace.dependencies.ed25519-dalek
+
 #[rstest]
 #[case::oz_fungible_allowlist("oz/fungible-allowlist")]
 #[case::oz_fungible_blocklist("oz/fungible-blocklist")]
 #[case::oz_fungible_capped("oz/fungible-capped")]
-#[case::oz_fungible_pausable("oz/fungible-pausable")] 
+#[case::oz_fungible_pausable("oz/fungible-pausable")]
 #[case::oz_fungible_vault("oz/fungible-vault")]
 #[case::oz_merkle_voting("oz/merkle-voting")]
 #[case::oz_nft_access_control("oz/nft-access-control")]
@@ -89,14 +96,6 @@ soroban_token_contract.client = false
 #[case::oz_ownable("oz/ownable")]
 #[case::oz_pausable("oz/pausable")]
 #[case::oz_sac_admin_wrapper("oz/sac-admin-wrapper")]
-
-// the following are commented out because they currently do not build from a freshly created scaffold project
-// #[case::oz_fungible_merkle_airdrop("oz/fungible-merkle-airdrop")] // also needs hex-literal as a workspace dev dependency
-// #[case::oz_multisig("oz/multisig")] - doesn't have a cargo.toml in the root of the example 
-// #[case::oz_upgradeable("oz/upgradeable")] - doesn't have a cargo.toml in the root of the example
-// #[case::oz_rwa("oz/rwa")] - error: symbol `__constructor` is already defined
-// #[case::oz_sac_admin_generic("oz/sac-admin-generic")] ❌ also needs workspace.dependencies.ed25519-dalek
-
 fn test_adding_and_building_oz_examples(#[case] input: &str) {
     TestEnv::from("soroban-init-boilerplate", |env| {
         env.set_environments_toml(format!(
@@ -140,4 +139,47 @@ soroban_token_contract.client = false
         // Run scaffold_build and assert success
         env.scaffold_build("development", true).assert().success();
     });
+}
+
+// this test makes sure that the OZ example repo release version that is included in new scaffold projects from the FE template is compatible with the current scaffold binary
+#[tokio::test]
+async fn test_scaffold_project_is_compatible_with_oz_examples(#[case] input: &str) {
+    TestEnv::from_init("test-project", |env| async move {
+        env.set_environments_toml(format!(
+            r#"
+[development]
+network = {{ rpc-url = "{}", network-passphrase = "Standalone Network ; February 2017" }}
+
+accounts = [
+    "alice",
+]
+[development.contracts]
+soroban_hello_world_contract.client = false
+soroban_increment_contract.client = false
+soroban_custom_types_contract.client = false
+soroban_auth_contract.client = false
+soroban_token_contract.client = false
+"#,
+            rpc_url()
+        ));
+
+        // generate all of these examples into an existing scaffold project
+        for example in vec![
+            "oz/fungible-allowlist",
+            "oz/fungible-capped",
+            "oz/fungible-pausible",
+        ] {
+            env.scaffold("generate")
+                .arg("contract")
+                .arg("--from")
+                .arg(input)
+                .assert()
+                .success()
+                .stdout_as_str();
+        }
+
+        // Run scaffold_build and assert success
+        env.scaffold_build("development", true).assert().success();
+    })
+    .await;
 }

--- a/crates/stellar-scaffold-test/fixtures/soroban-init-boilerplate/Cargo.toml
+++ b/crates/stellar-scaffold-test/fixtures/soroban-init-boilerplate/Cargo.toml
@@ -27,6 +27,10 @@ tag = "v0.5.1"
 git = "https://github.com/OpenZeppelin/stellar-contracts"
 tag = "v0.5.1"
 
+[workspace.dependencies.stellar-contract-utils]
+git = "https://github.com/OpenZeppelin/stellar-contracts"
+tag = "v0.5.1"
+
 [profile.release]
 opt-level = "z"
 overflow-checks = true

--- a/crates/stellar-scaffold-test/fixtures/soroban-init-boilerplate/Cargo.toml
+++ b/crates/stellar-scaffold-test/fixtures/soroban-init-boilerplate/Cargo.toml
@@ -5,12 +5,27 @@ members = [
 ]
 
 [workspace.package]
+authors = ["The Aha Company"]
 edition = "2024"
 version = "0.0.0"
+license = "Apache-2.0"
+repository = "https://github.com/theahaco/scaffold-stellar"
 
 [workspace.dependencies]
 soroban-sdk = "23.2.1"
 soroban-token-sdk = "23.2.1"
+
+[workspace.dependencies.stellar-access]
+git = "https://github.com/OpenZeppelin/stellar-contracts"
+tag = "v0.5.1"
+
+[workspace.dependencies.stellar-macros]
+git = "https://github.com/OpenZeppelin/stellar-contracts"
+tag = "v0.5.1"
+
+[workspace.dependencies.stellar-tokens]
+git = "https://github.com/OpenZeppelin/stellar-contracts"
+tag = "v0.5.1"
 
 [profile.release]
 opt-level = "z"


### PR DESCRIPTION
- Adds tests to ensure that oz examples can be generated and built with scaffold
- Creates a dependabot task to check soroban-init-boilerplate to remind us to update this repo with the most recent oz version