### PR TITLE
fix: use the action used by stellar-cli's CI instead of service

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build:
     name: build
-    runs-on: ubuntu-latest-8-core
+    runs-on: aha-ubuntu-latest-8-core
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,25 +86,14 @@ jobs:
       STELLAR_NETWORK_PASSPHRASE: "Standalone Network ; February 2017"
       STELLAR_ACCOUNT: default
       STELLAR_CONTRACT_ID: core
-    services:
-      rpc:
-        image: stellar/quickstart:testing
-        ports:
-          - 8000:8000
-        env:
-          ENABLE_LOGS: true
-          NETWORK: local
-          ENABLE_SOROBAN_RPC: true
-        options: >-
-          --health-cmd "curl --no-progress-meter --fail-with-body -X POST \"http://localhost:8000/soroban/rpc\" -H 'Content-Type: application/json' -d '{\"jsonrpc\":\"2.0\",\"id\":8675309,\"method\":\"getNetwork\"}' && curl --no-progress-meter \"http://localhost:8000/friendbot\" | grep '\"invalid_field\": \"addr\"'"
-          --health-interval 2s
-          --health-timeout 5s
-          --health-retries 50
     steps:
       - uses: actions/checkout@v6
       - uses: taiki-e/install-action@just
       - uses: taiki-e/install-action@nextest
       - uses: stellar/stellar-cli@v25.1.0
+      - uses: stellar/quickstart@main
+        with:
+          tag: testing
       - name: Download nextest archive
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
   test:
     name: test ${{ matrix.name }}
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: aha-ubuntu-latest-8-core
     strategy:
       fail-fast: false
       matrix:
@@ -87,13 +87,13 @@ jobs:
       STELLAR_ACCOUNT: default
       STELLAR_CONTRACT_ID: core
     steps:
+      - uses: stellar/quickstart@main
+        with:
+          tag: testing
       - uses: actions/checkout@v6
       - uses: taiki-e/install-action@just
       - uses: taiki-e/install-action@nextest
       - uses: stellar/stellar-cli@v25.1.0
-      - uses: stellar/quickstart@main
-        with:
-          tag: testing
       - name: Download nextest archive
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - uses: cargo-bins/cargo-binstall@main
       - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: stellar/stellar-cli@v25.1.0
       - run: just build
       - run: just build-cli-test-contracts
       - name: Create nextest archive

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build:
     name: build
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-8-core
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,6 @@ jobs:
       - uses: taiki-e/install-action@just
       - uses: taiki-e/install-action@nextest
       - uses: cargo-bins/cargo-binstall@main
-      - uses: stellar/stellar-cli@v25.1.0
       - uses: mozilla-actions/sccache-action@v0.0.9
       - run: just build
       - run: just build-cli-test-contracts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build:
     name: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"


### PR DESCRIPTION
It took only 30s compared to 150s currently.
