### PR TITLE
fix: add version to stellar-scaffold-cli for release

### DIFF
--- a/crates/stellar-scaffold-cli/Cargo.toml
+++ b/crates/stellar-scaffold-cli/Cargo.toml
@@ -26,7 +26,7 @@ doctest = false
 
 [dependencies]
 stellar-build = { path = "../stellar-build", version = "0.0.6" }
-stellar-scaffold-ext-types = { path = "../stellar-scaffold-ext-types" }
+stellar-scaffold-ext-types = { path = "../stellar-scaffold-ext-types", version = "0.0.1" }
 stellar-cli = { workspace = true, default-features = false }
 soroban-rpc = { workspace = true }
 soroban-spec-tools = { workspace = true }


### PR DESCRIPTION
## Summary
- Adds version field to `stellar-scaffold-cli` crate's `Cargo.toml` to fix the release process which requires crates to have a version specified.

## Test plan
- [ ] Verify release workflow succeeds with the version field present