### PR TITLE
Feat/reporter extension

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,12 +41,13 @@ jobs:
       - run: just build
       - run: just build-cli-test-contracts
       - name: Create nextest archive
-        run: cargo nextest archive --archive-file nextest-archive.tar.zst --package stellar-scaffold-cli --package stellar-registry-cli --features integration-tests
+        run: cargo nextest archive --archive-file nextest-archive.tar.zst --package stellar-scaffold-cli --package stellar-registry-cli --package stellar-scaffold-reporter --features integration-tests
       - name: Package runtime artifacts
         run: |
           tar -cf - \
             target/debug/stellar-scaffold \
             target/debug/stellar-registry \
+            target/debug/stellar-scaffold-reporter \
             target/stellar/local/ \
             crates/stellar-scaffold-test/fixtures/soroban-init-boilerplate/target/stellar/local/ \
             | zstd -1 -o runtime-artifacts.tar.zst
@@ -81,6 +82,8 @@ jobs:
             filter: "test-integration-scaffold-examples-2"
           - name: registry-cli
             filter: "test-integration-registry"
+          - name: reporter
+            filter: "test-integration-reporter"
     env:
       STELLAR_RPC_URL: http://localhost:8000/soroban/rpc
       STELLAR_NETWORK_PASSPHRASE: "Standalone Network ; February 2017"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4440,6 +4440,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellar-scaffold-reporter"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "serde",
+ "serde_json",
+ "stellar-scaffold-ext-types",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "stellar-scaffold-test"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,9 +48,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -63,44 +63,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arbitrary"
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbb6924530aa9e0432442af08bbcafdad182db80d2e560da42a6d442535bf85"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
 dependencies = [
  "anstyle",
  "bstr",
@@ -288,13 +288,12 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-compression"
-version = "0.4.33"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c1f86859c1af3d514fa19e8323147ff10ea98684e6c7b307912509f50e67b2"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
 dependencies = [
  "compression-codecs",
  "compression-core",
- "futures-core",
  "pin-project-lite",
  "tokio",
 ]
@@ -307,7 +306,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -348,9 +347,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "beef"
@@ -369,9 +368,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -403,9 +402,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.9.0",
  "hyper-named-pipe",
  "hyper-util",
  "hyperlocal",
@@ -416,7 +415,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_urlencoded",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tower-service",
@@ -449,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -467,9 +466,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytes-lit"
@@ -480,7 +479,7 @@ dependencies = [
  "num-bigint",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -491,9 +490,9 @@ checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
 
 [[package]]
 name = "camino"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 dependencies = [
  "serde_core",
 ]
@@ -528,24 +527,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
- "toml 0.9.8",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.45"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -567,14 +560,14 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -586,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.51"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -596,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.51"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -608,36 +601,36 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e602857739c5a4291dfa33b5a298aeac9006185229a700e5810a3ef7272d971"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -651,11 +644,11 @@ dependencies = [
 
 [[package]]
 name = "colored"
-version = "3.0.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -670,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.32"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680dc087785c5230f8e8843e2e57ac7c1c90488b6a91b88caa265410568f441b"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
 dependencies = [
  "compression-core",
  "flate2",
@@ -681,20 +674,19 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9b614a5787ef0c8802a55766480563cb3a93b435898c422ed2a359cf811582"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "console"
-version = "0.16.1"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
- "unicode-width 0.2.2",
+ "unicode-width",
  "windows-sys 0.61.2",
 ]
 
@@ -886,7 +878,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -901,12 +893,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -920,21 +912,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -945,25 +936,25 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core 0.23.0",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "degit-rs"
@@ -972,7 +963,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3fbe021db08caf0ff8d5f75768a76675ee583c7f70891916385714ad297b23b"
 dependencies = [
  "clap",
- "colored 3.0.0",
+ "colored 3.1.1",
  "flate2",
  "indicatif",
  "regex",
@@ -992,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -1019,7 +1010,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1080,16 +1071,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,17 +1095,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users 0.4.6",
- "winapi",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,7 +1102,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1272,9 +1242,9 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -1294,27 +1264,26 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
 dependencies = [
  "cfg-if",
  "libc",
  "libredox",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1334,6 +1303,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -1367,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1382,9 +1357,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1392,15 +1367,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1409,32 +1384,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
@@ -1444,9 +1419,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1456,7 +1431,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1473,9 +1447,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1493,9 +1467,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1523,7 +1511,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "ignore",
  "walkdir",
 ]
@@ -1551,7 +1539,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1560,17 +1548,17 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
- "indexmap 2.12.0",
+ "http 1.4.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1603,9 +1591,18 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heapless"
@@ -1679,12 +1676,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1740,12 +1731,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1767,7 +1757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1778,7 +1768,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -1827,22 +1817,21 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.12",
- "http 1.3.1",
+ "h2 0.4.13",
+ "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1855,7 +1844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper 1.7.0",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1885,10 +1874,10 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.3.1",
- "hyper 1.7.0",
+ "http 1.4.0",
+ "hyper 1.9.0",
  "hyper-util",
- "rustls 0.23.35",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -1898,23 +1887,22 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.7.0",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1928,7 +1916,7 @@ checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1937,9 +1925,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1961,12 +1949,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1974,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1987,9 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2001,15 +1990,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2021,15 +2010,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2039,6 +2028,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -2116,12 +2111,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -2134,24 +2129,24 @@ checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
 name = "indicatif"
-version = "0.18.2"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade6dfcba0dfb62ad59e59e7241ec8912af34fd29e0e743e3db992bd278e8b65"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
  "portable-atomic",
- "unicode-width 0.2.2",
+ "unicode-width",
  "unit-prefix",
  "web-time",
 ]
 
 [[package]]
 name = "inotify"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "inotify-sys",
  "libc",
 ]
@@ -2167,15 +2162,15 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.9"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -2188,17 +2183,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2237,38 +2221,67 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
+ "jni-macros",
  "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2340,9 +2353,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]
@@ -2380,26 +2393,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
-name = "libc"
-version = "0.2.177"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.184"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
- "redox_syscall",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2410,15 +2430,15 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -2431,9 +2451,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru-slab"
@@ -2449,7 +2469,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2463,9 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miniz_oxide"
@@ -2479,9 +2499,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -2525,7 +2545,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -2539,9 +2559,12 @@ dependencies = [
 
 [[package]]
 name = "notify-types"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -2564,9 +2587,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -2576,7 +2599,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2599,9 +2622,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
 ]
@@ -2618,15 +2641,15 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "objc2",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2642,9 +2665,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open"
-version = "5.3.2"
+version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2483562e62ea94312f3576a7aca397306df7990b8d89033e18766744377ef95"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
 dependencies = [
  "is-wsl",
  "libc",
@@ -2702,7 +2725,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -2764,7 +2787,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2778,35 +2801,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs8"
@@ -2819,16 +2836,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "portable-atomic"
-version = "1.11.1"
+name = "plain"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2850,9 +2873,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
 dependencies = [
  "anstyle",
  "difflib",
@@ -2864,15 +2887,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -2885,21 +2908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.110",
-]
-
-[[package]]
-name = "prettytable"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46480520d1b77c9a3482d39939fcf96831537a250ec62d4fd8fbdf8e0302e781"
-dependencies = [
- "csv",
- "encode_unicode",
- "is-terminal",
- "lazy_static",
- "term",
- "unicode-width 0.1.14",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2913,18 +2922,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.23.9",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -2940,10 +2949,10 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
- "rustls 0.23.35",
- "socket2 0.6.1",
- "thiserror 2.0.17",
+ "rustc-hash 2.1.2",
+ "rustls 0.23.37",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -2951,20 +2960,20 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash 2.1.1",
- "rustls 0.23.35",
+ "rustc-hash 2.1.2",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2979,16 +2988,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2998,6 +3007,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -3017,7 +3032,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -3037,7 +3062,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3046,17 +3071,23 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "redox_syscall"
@@ -3064,7 +3095,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3073,7 +3113,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -3084,9 +3124,9 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3106,26 +3146,26 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "reflink-copy"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbed272e39c47a095a5242218a67412a220006842558b03fe2935e8f3d7b92"
+checksum = "13362233b147e57674c37b802d216b7c5e3dcccbed8967c84f0d8d223868ae27"
 dependencies = [
  "cfg-if",
  "libc",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "windows",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3135,9 +3175,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3146,9 +3186,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "registry"
@@ -3172,20 +3212,20 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.12",
- "http 1.3.1",
+ "h2 0.4.13",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.9.0",
  "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
@@ -3193,7 +3233,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.35",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3202,7 +3242,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-util",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -3231,7 +3271,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -3273,7 +3313,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.110",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
@@ -3289,9 +3329,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "8.9.0"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "947d7f3fad52b283d261c4c99a084937e2fe492248cb9a68a8435a861b8798ca"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -3300,22 +3340,22 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.9.0"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fa2c8c9e8711e10f9c4fd2d64317ef13feaab820a4c51541f1a8c8e2e851ab2"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
 dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.110",
+ "syn 2.0.117",
  "walkdir",
 ]
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.9.0"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
  "sha2 0.10.9",
  "walkdir",
@@ -3329,9 +3369,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3348,7 +3388,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3357,14 +3397,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3382,14 +3422,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.35"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.8",
+ "rustls-webpki 0.103.11",
  "subtle",
  "zeroize",
 ]
@@ -3417,9 +3457,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3437,9 +3477,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3454,9 +3494,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3469,9 +3509,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -3502,9 +3542,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -3521,7 +3561,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3559,7 +3599,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -3568,9 +3608,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3578,9 +3618,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -3647,7 +3687,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3658,20 +3698,20 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -3682,7 +3722,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3696,9 +3736,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.3"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -3717,18 +3757,18 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.15.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa66c845eee442168b2c8134fec70ac50dc20e760769c8ba0ad1319ca1959b04"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "schemars 0.8.22",
  "schemars 0.9.0",
- "schemars 1.1.0",
+ "schemars 1.2.1",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -3737,14 +3777,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.15.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91a903660542fced4e99881aa481bdbaec1634568ee02e0b8bd57c64cb38955"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3798,9 +3838,9 @@ checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
 name = "shell-words"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -3810,10 +3850,11 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -3829,9 +3870,25 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -3841,24 +3898,25 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slipped10"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a45443e66aa5d96db5e02d17db056e1ca970232a4fe73e1f9bc1816d68f4e98"
+checksum = "0467009f63d9ec6920100ddb026ccdb8b661ba37aaa86664c5e9ac3a4e3e316b"
 dependencies = [
  "ed25519-dalek",
  "hmac 0.9.0",
+ "rand 0.10.0",
  "sha2 0.9.9",
 ]
 
@@ -3880,12 +3938,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3897,14 +3955,14 @@ dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "soroban-cli"
-version = "25.1.0"
+version = "25.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06b132b80a5e55ae70dba39c68e34d3b8958065e9c3d9bba58444b123fabd0aa"
+checksum = "b7c4104614e8dc2daad0f596159ee193033f53f9b3cea303bcb693a481592ab1"
 dependencies = [
  "async-compression",
  "async-trait",
@@ -3930,6 +3988,7 @@ dependencies = [
  "hex",
  "home",
  "humantime",
+ "indexmap 2.14.0",
  "itertools 0.10.5",
  "jsonrpsee-core",
  "jsonrpsee-http-client",
@@ -3937,7 +3996,6 @@ dependencies = [
  "open",
  "pathdiff",
  "phf",
- "prettytable",
  "rand 0.8.5",
  "regex",
  "reqwest",
@@ -3956,7 +4014,6 @@ dependencies = [
  "soroban-ledger-snapshot",
  "soroban-sdk",
  "soroban-spec",
- "soroban-spec-json",
  "soroban-spec-rust",
  "soroban-spec-tools",
  "soroban-spec-typescript",
@@ -3981,7 +4038,7 @@ dependencies = [
  "ulid",
  "url",
  "wasm-gen",
- "wasmparser",
+ "wasmparser 0.116.1",
  "which",
  "whoami",
  "zeroize",
@@ -4003,7 +4060,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-xdr 25.0.0",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -4032,7 +4089,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "hex-literal",
  "hmac 0.12.1",
  "k256",
@@ -4050,7 +4107,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey 0.0.13",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -4065,14 +4122,14 @@ dependencies = [
  "serde",
  "serde_json",
  "stellar-xdr 25.0.0",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "25.1.1"
+version = "25.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d569a1315f05216d024653ad87541aa15d3ff26dad9f8a98719cb53ccf2bf3"
+checksum = "2ca06e6c5029d1285e66219cb387a234224e26969ce8ad2bc2d5017e9395d63b"
 dependencies = [
  "serde",
  "serde_json",
@@ -4084,9 +4141,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "25.1.1"
+version = "25.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add8d19cfd2c9941bbdc7c8223c3cf9d7ff9af4554ba3bd4ae93e16b19b08aea"
+checksum = "4502f2e018f238a4c5d3212d7d20ea6abcdc6e58babd63b642b693739db30fd1"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -4108,9 +4165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "25.1.1"
+version = "25.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0107e34575ec704ce29407695462e79e6b0e13ce7af6431b2f15c313e34464"
+checksum = "ca03e9cf61d241cb9afdd6ddf41f6c25698b3f566a875e7009ea799b89e2bf0a"
 dependencies = [
  "darling 0.20.11",
  "heck 0.5.0",
@@ -4123,41 +4180,27 @@ dependencies = [
  "soroban-spec",
  "soroban-spec-rust",
  "stellar-xdr 25.0.0",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "soroban-spec"
-version = "25.1.1"
+version = "25.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a1c9f6ccc6aa78518545e3cf542bd26f11d9085328a2e1c06c90514733fe15"
+checksum = "aa02e07f507cc27406ae0834db4dcf309b78c4cc8776eb3b2d662d66e8859d25"
 dependencies = [
  "base64 0.22.1",
+ "sha2 0.10.9",
  "stellar-xdr 25.0.0",
  "thiserror 1.0.69",
- "wasmparser",
-]
-
-[[package]]
-name = "soroban-spec-json"
-version = "25.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d582304c479e3a9624f3ecfb50aa6286d3886eb2d4f9892fafc1b9812d64d5f"
-dependencies = [
- "serde",
- "serde_derive",
- "serde_json",
- "sha2 0.9.9",
- "soroban-spec",
- "stellar-xdr 25.0.0",
- "thiserror 1.0.69",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
 name = "soroban-spec-rust"
-version = "25.1.1"
+version = "25.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8247d3c6256b544b2461606c6892351bb22978d751e07c1aea744377053d852"
+checksum = "6835bb510763ef3fa5405e89036e3c8ea6ef5abe55fc52cfe9ac0e38be9d531c"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -4165,33 +4208,37 @@ dependencies = [
  "sha2 0.10.9",
  "soroban-spec",
  "stellar-xdr 25.0.0",
- "syn 2.0.110",
+ "syn 2.0.117",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "soroban-spec-tools"
-version = "25.1.0"
+version = "25.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d103e30018da2ec352ca1d45b59844369cf8532a437156a5a8dc9af99fb0e1da"
+checksum = "adbd3c5741031e88bd3e19d8efa7d4f5da63e000f8dd79569b382ce4f1cb54c9"
 dependencies = [
  "base64 0.21.7",
+ "escape-bytes",
  "ethnum",
  "hex",
+ "indexmap 2.14.0",
  "itertools 0.10.5",
+ "serde",
  "serde_json",
  "soroban-spec",
  "stellar-strkey 0.0.15",
  "stellar-xdr 25.0.0",
  "thiserror 1.0.69",
- "wasmparser",
+ "wasm-encoder 0.235.0",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
 name = "soroban-spec-typescript"
-version = "25.1.0"
+version = "25.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25684cb264ba39bac049ba93fc66fd241993c9aefb82d60d60417736408ec61a"
+checksum = "1d95b7aca1351b3258e516ba106dfdcc9dff3496f9b286938e96d6dd19da362c"
 dependencies = [
  "base64 0.21.7",
  "heck 0.4.1",
@@ -4209,18 +4256,18 @@ dependencies = [
 
 [[package]]
 name = "soroban-token-sdk"
-version = "25.1.0"
+version = "25.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3dbb65b7a5418c0b0daff7b467bddb54cdc9a769ba9737417fbe3d8d5614f62"
+checksum = "d8230fe7cf1bf138068cbe5cfa54a76657bed8a9bb6a89a4a229383116d3f067"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "soroban-token-spec"
-version = "25.1.0"
+version = "25.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9aaafe26a24bcfcbfa57ecce63d694ef245a3469d687a5d084d197b209fab0"
+checksum = "c7a7e016becd17190ac5960bc3b591adbec158fda4e739d861b4f63dd8cd337c"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",
@@ -4269,9 +4316,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellar-asset-spec"
-version = "25.1.0"
+version = "25.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "294e96de0005e69c839405393e123a08ee5ace4bd91d5fbcc8ad33c92cd0497e"
+checksum = "c245a68279b5f31fba7ceb3ca2d00a602eabc7055afb8f7a671c886d4b5a94ed"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",
@@ -4284,7 +4331,7 @@ version = "0.0.6"
 dependencies = [
  "cargo_metadata",
  "sha2 0.10.9",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "topological-sort",
 ]
 
@@ -4309,7 +4356,7 @@ dependencies = [
  "stellar-build",
  "stellar-rpc-client",
  "stellar-strkey 0.0.15",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -4337,19 +4384,19 @@ dependencies = [
  "stellar-rpc-client",
  "stellar-scaffold-test",
  "stellar-strkey 0.0.15",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
 [[package]]
 name = "stellar-rpc-client"
-version = "25.0.0"
+version = "25.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22c11b19c588a2f46421e142100f8ec38958307a04a16ab34f8c14d23e9b7395"
+checksum = "9a72922387b5c3d48f9978795f1c6a81f3b48467951e3073cdd7a93824ba659f"
 dependencies = [
  "clap",
  "hex",
- "http 1.3.1",
+ "http 1.4.0",
  "itertools 0.10.5",
  "jsonrpsee-core",
  "jsonrpsee-http-client",
@@ -4384,7 +4431,7 @@ dependencies = [
  "heck 0.5.0",
  "hex",
  "ignore",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "mockito",
  "notify",
@@ -4407,11 +4454,11 @@ dependencies = [
  "stellar-xdr 25.0.0",
  "tar",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "toml 0.9.8",
- "toml_edit 0.23.9",
+ "toml 0.9.12+spec-1.1.0",
+ "toml_edit 0.23.10+spec-1.0.0",
  "uuid",
  "walkdir",
  "webbrowser",
@@ -4436,7 +4483,7 @@ dependencies = [
  "stellar-build",
  "stellar-strkey 0.0.13",
  "stellar-xdr 23.0.0",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4447,7 +4494,7 @@ dependencies = [
  "serde",
  "serde_json",
  "stellar-scaffold-ext-types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4596,9 +4643,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4622,14 +4669,14 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",
@@ -4638,26 +4685,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
 ]
 
 [[package]]
@@ -4702,11 +4738,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -4717,18 +4753,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4742,30 +4778,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4792,9 +4828,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4802,9 +4838,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4817,9 +4853,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -4827,20 +4863,20 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4859,15 +4895,15 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.35",
+ "rustls 0.23.37",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4876,9 +4912,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4902,17 +4938,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.8"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "serde_core",
- "serde_spanned 1.0.3",
- "toml_datetime 0.7.3",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -4926,9 +4962,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.3"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -4939,34 +4984,46 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.9"
+version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7cbc3b4b49633d57a0509303158ca50de80ae32c265093b24c414705807832"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap 2.12.0",
- "toml_datetime 0.7.3",
+ "indexmap 2.14.0",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -4977,9 +5034,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.4"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "topological-sort"
@@ -5004,9 +5061,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -5019,18 +5076,18 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -5049,9 +5106,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -5061,32 +5118,32 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -5105,9 +5162,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -5146,9 +5203,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
@@ -5161,15 +5218,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -5178,10 +5229,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unit-prefix"
-version = "0.5.1"
+name = "unicode-xid"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "untrusted"
@@ -5191,9 +5248,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -5215,11 +5272,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -5244,7 +5301,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5283,9 +5340,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -5298,9 +5364,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5311,22 +5377,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5334,24 +5397,44 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.235.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3bc393c395cb621367ff02d854179882b9a351b4e0c93d1397e6090b53a5c2a"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.235.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -5362,6 +5445,18 @@ checksum = "b854b1461005a7b3365742310f7faa3cac3add809d66928c64a40c7e9e842ebb"
 dependencies = [
  "byteorder 0.5.3",
  "leb128",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -5401,7 +5496,30 @@ version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.235.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
+dependencies = [
+ "bitflags 2.11.0",
+ "indexmap 2.14.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -5416,9 +5534,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5436,9 +5554,9 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.0.6"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f1243ef785213e3a32fa0396093424a3a6ea566f9948497e5a2309261a4c97"
+checksum = "fe985f41e291eecef5e5c0770a18d28390addb03331c043964d9e916453d6f16"
 dependencies = [
  "core-foundation 0.10.1",
  "jni",
@@ -5452,9 +5570,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5567,7 +5685,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5578,7 +5696,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5613,15 +5731,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -5667,21 +5776,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5743,12 +5837,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -5767,12 +5855,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -5788,12 +5870,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5827,12 +5903,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -5848,12 +5918,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5875,12 +5939,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -5896,12 +5954,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5923,24 +5975,115 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.244.0",
+ "wasm-metadata",
+ "wasmparser 0.244.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.244.0",
+]
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xattr"
@@ -5949,14 +6092,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.2",
+ "rustix 1.1.4",
 ]
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5965,54 +6108,54 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -6027,20 +6170,20 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -6049,9 +6192,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6060,11 +6203,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4402,7 +4402,6 @@ dependencies = [
  "stellar-build",
  "stellar-rpc-client",
  "stellar-scaffold-ext-types",
- "stellar-scaffold-reporter",
  "stellar-scaffold-test",
  "stellar-strkey 0.0.15",
  "stellar-xdr 25.0.0",
@@ -4444,10 +4443,12 @@ dependencies = [
 name = "stellar-scaffold-reporter"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
  "clap",
  "serde",
  "serde_json",
  "stellar-scaffold-ext-types",
+ "stellar-scaffold-test",
  "thiserror 2.0.17",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,9 +48,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "1.0.0"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -63,44 +63,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.14"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "1.0.0"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.5"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.11"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arbitrary"
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+checksum = "bcbb6924530aa9e0432442af08bbcafdad182db80d2e560da42a6d442535bf85"
 dependencies = [
  "anstyle",
  "bstr",
@@ -288,12 +288,13 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-compression"
-version = "0.4.41"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+checksum = "93c1f86859c1af3d514fa19e8323147ff10ea98684e6c7b307912509f50e67b2"
 dependencies = [
  "compression-codecs",
  "compression-core",
+ "futures-core",
  "pin-project-lite",
  "tokio",
 ]
@@ -306,7 +307,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -347,9 +348,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "beef"
@@ -368,9 +369,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "block-buffer"
@@ -402,9 +403,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "http 1.4.0",
+ "http 1.3.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.7.0",
  "hyper-named-pipe",
  "hyper-util",
  "hyperlocal",
@@ -415,7 +416,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_urlencoded",
- "thiserror 2.0.18",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-util",
  "tower-service",
@@ -448,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
@@ -466,9 +467,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bytes-lit"
@@ -479,7 +480,7 @@ dependencies = [
  "num-bigint",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -490,9 +491,9 @@ checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
 
 [[package]]
 name = "camino"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+checksum = "276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609"
 dependencies = [
  "serde_core",
 ]
@@ -527,18 +528,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
- "toml 0.9.12+spec-1.1.0",
+ "toml 0.9.8",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
 dependencies = [
  "find-msvc-tools",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -560,14 +567,14 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -579,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -589,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -601,36 +608,36 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.0"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+checksum = "8e602857739c5a4291dfa33b5a298aeac9006185229a700e5810a3ef7272d971"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "1.1.0"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.5"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colored"
@@ -644,11 +651,11 @@ dependencies = [
 
 [[package]]
 name = "colored"
-version = "3.1.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -663,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.37"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+checksum = "680dc087785c5230f8e8843e2e57ac7c1c90488b6a91b88caa265410568f441b"
 dependencies = [
  "compression-core",
  "flate2",
@@ -674,19 +681,20 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.31"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+checksum = "3a9b614a5787ef0c8802a55766480563cb3a93b435898c422ed2a359cf811582"
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width",
+ "once_cell",
+ "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
 
@@ -878,7 +886,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -893,12 +901,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -912,20 +920,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
+ "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -936,25 +945,25 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core 0.21.3",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "degit-rs"
@@ -963,7 +972,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3fbe021db08caf0ff8d5f75768a76675ee583c7f70891916385714ad297b23b"
 dependencies = [
  "clap",
- "colored 3.1.1",
+ "colored 3.0.0",
  "flate2",
  "indicatif",
  "regex",
@@ -983,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.8"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -1010,7 +1019,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1071,6 +1080,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,6 +1114,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,7 +1132,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1242,9 +1272,9 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
@@ -1264,26 +1294,27 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
 dependencies = [
  "cfg-if",
  "libc",
  "libredox",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1303,12 +1334,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -1342,9 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1357,9 +1382,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1367,15 +1392,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1384,32 +1409,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-timer"
@@ -1419,9 +1444,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1431,6 +1456,7 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
+ "pin-utils",
  "slab",
 ]
 
@@ -1447,9 +1473,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1467,23 +1493,9 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi 5.3.0",
+ "r-efi",
  "wasip2",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
- "rand_core 0.10.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1511,7 +1523,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "ignore",
  "walkdir",
 ]
@@ -1539,7 +1551,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.14.0",
+ "indexmap 2.12.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1548,17 +1560,17 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
- "indexmap 2.14.0",
+ "http 1.3.1",
+ "indexmap 2.12.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1591,18 +1603,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "heapless"
@@ -1676,6 +1679,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,11 +1740,12 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
+ "fnv",
  "itoa",
 ]
 
@@ -1757,7 +1767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -1768,7 +1778,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -1817,21 +1827,22 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
+ "h2 0.4.12",
+ "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1844,7 +1855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper 1.9.0",
+ "hyper 1.7.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1874,10 +1885,10 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.4.0",
- "hyper 1.9.0",
+ "http 1.3.1",
+ "hyper 1.7.0",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls 0.23.35",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -1887,22 +1898,23 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.20"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.3.1",
  "http-body 1.0.1",
- "hyper 1.9.0",
+ "hyper 1.7.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -1916,7 +1928,7 @@ checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.7.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1925,9 +1937,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.65"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1949,13 +1961,12 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
- "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1963,9 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1976,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1990,15 +2001,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2010,15 +2021,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2028,12 +2039,6 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -2111,12 +2116,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.16.0",
  "serde",
  "serde_core",
 ]
@@ -2129,24 +2134,24 @@ checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "ade6dfcba0dfb62ad59e59e7241ec8912af34fd29e0e743e3db992bd278e8b65"
 dependencies = [
  "console",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.2",
  "unit-prefix",
  "web-time",
 ]
 
 [[package]]
 name = "inotify"
-version = "0.11.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "inotify-sys",
  "libc",
 ]
@@ -2162,15 +2167,15 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri-string"
-version = "0.7.12"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
 dependencies = [
  "memchr",
  "serde",
@@ -2183,6 +2188,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2221,67 +2237,38 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.18"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jni"
-version = "0.22.4"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
+ "cesu8",
  "cfg-if",
  "combine",
- "jni-macros",
  "jni-sys",
  "log",
- "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "walkdir",
- "windows-link",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn 2.0.117",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "jni-sys"
-version = "0.4.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
- "quote",
- "syn 2.0.117",
-]
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
 dependencies = [
- "cfg-if",
- "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2353,9 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.6"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
 ]
@@ -2393,33 +2380,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libm"
-version = "0.2.16"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "libc",
- "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -2430,15 +2410,15 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.12.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
@@ -2451,9 +2431,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lru-slab"
@@ -2469,7 +2449,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2483,9 +2463,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "miniz_oxide"
@@ -2499,9 +2479,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
  "log",
@@ -2545,7 +2525,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -2559,12 +2539,9 @@ dependencies = [
 
 [[package]]
 name = "notify-types"
-version = "2.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
-dependencies = [
- "bitflags 2.11.0",
-]
+checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2587,9 +2564,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-derive"
@@ -2599,7 +2576,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2622,9 +2599,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
 dependencies = [
  "objc2-encode",
 ]
@@ -2641,15 +2618,15 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "objc2",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.21.4"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2665,9 +2642,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open"
-version = "5.3.3"
+version = "5.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+checksum = "e2483562e62ea94312f3576a7aca397306df7990b8d89033e18766744377ef95"
 dependencies = [
  "is-wsl",
  "libc",
@@ -2725,7 +2702,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -2787,7 +2764,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2801,29 +2778,35 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.17"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
@@ -2836,22 +2819,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
@@ -2873,9 +2850,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "3.1.4"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "difflib",
@@ -2887,15 +2864,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.10"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.13"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -2908,7 +2885,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "prettytable"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46480520d1b77c9a3482d39939fcf96831537a250ec62d4fd8fbdf8e0302e781"
+dependencies = [
+ "csv",
+ "encode_unicode",
+ "is-terminal",
+ "lazy_static",
+ "term",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -2922,18 +2913,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.5.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit 0.23.9",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -2949,10 +2940,10 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.2",
- "rustls 0.23.37",
- "socket2 0.6.3",
- "thiserror 2.0.18",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.35",
+ "socket2 0.6.1",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "web-time",
@@ -2960,20 +2951,20 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash 2.1.2",
- "rustls 0.23.37",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.35",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.17",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2988,16 +2979,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.6.1",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -3007,12 +2998,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -3032,17 +3017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
-dependencies = [
- "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3062,7 +3037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3071,23 +3046,17 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.17",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "redox_syscall"
@@ -3095,16 +3064,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
-dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -3113,7 +3073,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.17",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -3124,9 +3084,9 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom 0.2.17",
+ "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3146,26 +3106,26 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "reflink-copy"
-version = "0.1.29"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13362233b147e57674c37b802d216b7c5e3dcccbed8967c84f0d8d223868ae27"
+checksum = "23bbed272e39c47a095a5242218a67412a220006842558b03fe2935e8f3d7b92"
 dependencies = [
  "cfg-if",
  "libc",
- "rustix 1.1.4",
+ "rustix 1.1.2",
  "windows",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3175,9 +3135,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3186,9 +3146,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "registry"
@@ -3212,20 +3172,20 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
- "http 1.4.0",
+ "h2 0.4.12",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.7.0",
  "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
@@ -3233,7 +3193,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls 0.23.35",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3242,7 +3202,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-util",
- "tower 0.5.3",
+ "tower 0.5.2",
  "tower-http",
  "tower-service",
  "url",
@@ -3271,7 +3231,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.17",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -3313,7 +3273,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.110",
  "unicode-ident",
 ]
 
@@ -3329,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "8.11.0"
+version = "8.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+checksum = "947d7f3fad52b283d261c4c99a084937e2fe492248cb9a68a8435a861b8798ca"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -3340,22 +3300,22 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.11.0"
+version = "8.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+checksum = "5fa2c8c9e8711e10f9c4fd2d64317ef13feaab820a4c51541f1a8c8e2e851ab2"
 dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.117",
+ "syn 2.0.110",
  "walkdir",
 ]
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.11.0"
+version = "8.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
 dependencies = [
  "sha2 0.10.9",
  "walkdir",
@@ -3369,9 +3329,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -3388,7 +3348,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3397,14 +3357,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.4"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -3422,14 +3382,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.11",
+ "rustls-webpki 0.103.8",
  "subtle",
  "zeroize",
 ]
@@ -3457,9 +3417,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3477,9 +3437,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3494,9 +3454,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.23"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -3509,9 +3469,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.29"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -3542,9 +3502,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -3561,7 +3521,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3599,7 +3559,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -3608,9 +3568,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.17.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3618,9 +3578,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.28"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 dependencies = [
  "serde",
  "serde_core",
@@ -3687,7 +3647,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3698,20 +3658,20 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
+ "ryu",
  "serde",
  "serde_core",
- "zmij",
 ]
 
 [[package]]
@@ -3722,7 +3682,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3736,9 +3696,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
 dependencies = [
  "serde_core",
 ]
@@ -3757,18 +3717,18 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "aa66c845eee442168b2c8134fec70ac50dc20e760769c8ba0ad1319ca1959b04"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.14.0",
+ "indexmap 2.12.0",
  "schemars 0.8.22",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.1.0",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -3777,14 +3737,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "b91a903660542fced4e99881aa481bdbaec1634568ee02e0b8bd57c64cb38955"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3838,9 +3798,9 @@ checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
 name = "shell-words"
-version = "1.1.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shlex"
@@ -3850,11 +3810,10 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.8"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
- "errno",
  "libc",
 ]
 
@@ -3870,25 +3829,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
-name = "simd_cesu8"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
-dependencies = [
- "rustc_version",
- "simdutf8",
-]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "similar"
@@ -3898,25 +3841,24 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.12"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slipped10"
-version = "0.4.7"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0467009f63d9ec6920100ddb026ccdb8b661ba37aaa86664c5e9ac3a4e3e316b"
+checksum = "0a45443e66aa5d96db5e02d17db056e1ca970232a4fe73e1f9bc1816d68f4e98"
 dependencies = [
  "ed25519-dalek",
  "hmac 0.9.0",
- "rand 0.10.0",
  "sha2 0.9.9",
 ]
 
@@ -3938,12 +3880,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3955,14 +3897,14 @@ dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "soroban-cli"
-version = "25.2.0"
+version = "25.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c4104614e8dc2daad0f596159ee193033f53f9b3cea303bcb693a481592ab1"
+checksum = "06b132b80a5e55ae70dba39c68e34d3b8958065e9c3d9bba58444b123fabd0aa"
 dependencies = [
  "async-compression",
  "async-trait",
@@ -3988,7 +3930,6 @@ dependencies = [
  "hex",
  "home",
  "humantime",
- "indexmap 2.14.0",
  "itertools 0.10.5",
  "jsonrpsee-core",
  "jsonrpsee-http-client",
@@ -3996,6 +3937,7 @@ dependencies = [
  "open",
  "pathdiff",
  "phf",
+ "prettytable",
  "rand 0.8.5",
  "regex",
  "reqwest",
@@ -4014,6 +3956,7 @@ dependencies = [
  "soroban-ledger-snapshot",
  "soroban-sdk",
  "soroban-spec",
+ "soroban-spec-json",
  "soroban-spec-rust",
  "soroban-spec-tools",
  "soroban-spec-typescript",
@@ -4038,7 +3981,7 @@ dependencies = [
  "ulid",
  "url",
  "wasm-gen",
- "wasmparser 0.116.1",
+ "wasmparser",
  "which",
  "whoami",
  "zeroize",
@@ -4060,7 +4003,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-xdr 25.0.0",
- "wasmparser 0.116.1",
+ "wasmparser",
 ]
 
 [[package]]
@@ -4089,7 +4032,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
- "getrandom 0.2.17",
+ "getrandom 0.2.16",
  "hex-literal",
  "hmac 0.12.1",
  "k256",
@@ -4107,7 +4050,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey 0.0.13",
- "wasmparser 0.116.1",
+ "wasmparser",
 ]
 
 [[package]]
@@ -4122,14 +4065,14 @@ dependencies = [
  "serde",
  "serde_json",
  "stellar-xdr 25.0.0",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "25.3.1"
+version = "25.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ca06e6c5029d1285e66219cb387a234224e26969ce8ad2bc2d5017e9395d63b"
+checksum = "66d569a1315f05216d024653ad87541aa15d3ff26dad9f8a98719cb53ccf2bf3"
 dependencies = [
  "serde",
  "serde_json",
@@ -4141,9 +4084,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "25.3.1"
+version = "25.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4502f2e018f238a4c5d3212d7d20ea6abcdc6e58babd63b642b693739db30fd1"
+checksum = "add8d19cfd2c9941bbdc7c8223c3cf9d7ff9af4554ba3bd4ae93e16b19b08aea"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -4165,9 +4108,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "25.3.1"
+version = "25.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca03e9cf61d241cb9afdd6ddf41f6c25698b3f566a875e7009ea799b89e2bf0a"
+checksum = "2a0107e34575ec704ce29407695462e79e6b0e13ce7af6431b2f15c313e34464"
 dependencies = [
  "darling 0.20.11",
  "heck 0.5.0",
@@ -4180,27 +4123,41 @@ dependencies = [
  "soroban-spec",
  "soroban-spec-rust",
  "stellar-xdr 25.0.0",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "soroban-spec"
-version = "25.3.1"
+version = "25.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa02e07f507cc27406ae0834db4dcf309b78c4cc8776eb3b2d662d66e8859d25"
+checksum = "53a1c9f6ccc6aa78518545e3cf542bd26f11d9085328a2e1c06c90514733fe15"
 dependencies = [
  "base64 0.22.1",
- "sha2 0.10.9",
  "stellar-xdr 25.0.0",
  "thiserror 1.0.69",
- "wasmparser 0.116.1",
+ "wasmparser",
+]
+
+[[package]]
+name = "soroban-spec-json"
+version = "25.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d582304c479e3a9624f3ecfb50aa6286d3886eb2d4f9892fafc1b9812d64d5f"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.9.9",
+ "soroban-spec",
+ "stellar-xdr 25.0.0",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "soroban-spec-rust"
-version = "25.3.1"
+version = "25.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6835bb510763ef3fa5405e89036e3c8ea6ef5abe55fc52cfe9ac0e38be9d531c"
+checksum = "e8247d3c6256b544b2461606c6892351bb22978d751e07c1aea744377053d852"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -4208,37 +4165,33 @@ dependencies = [
  "sha2 0.10.9",
  "soroban-spec",
  "stellar-xdr 25.0.0",
- "syn 2.0.117",
+ "syn 2.0.110",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "soroban-spec-tools"
-version = "25.2.0"
+version = "25.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd3c5741031e88bd3e19d8efa7d4f5da63e000f8dd79569b382ce4f1cb54c9"
+checksum = "d103e30018da2ec352ca1d45b59844369cf8532a437156a5a8dc9af99fb0e1da"
 dependencies = [
  "base64 0.21.7",
- "escape-bytes",
  "ethnum",
  "hex",
- "indexmap 2.14.0",
  "itertools 0.10.5",
- "serde",
  "serde_json",
  "soroban-spec",
  "stellar-strkey 0.0.15",
  "stellar-xdr 25.0.0",
  "thiserror 1.0.69",
- "wasm-encoder 0.235.0",
- "wasmparser 0.116.1",
+ "wasmparser",
 ]
 
 [[package]]
 name = "soroban-spec-typescript"
-version = "25.2.0"
+version = "25.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d95b7aca1351b3258e516ba106dfdcc9dff3496f9b286938e96d6dd19da362c"
+checksum = "25684cb264ba39bac049ba93fc66fd241993c9aefb82d60d60417736408ec61a"
 dependencies = [
  "base64 0.21.7",
  "heck 0.4.1",
@@ -4256,18 +4209,18 @@ dependencies = [
 
 [[package]]
 name = "soroban-token-sdk"
-version = "25.3.1"
+version = "25.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8230fe7cf1bf138068cbe5cfa54a76657bed8a9bb6a89a4a229383116d3f067"
+checksum = "c3dbb65b7a5418c0b0daff7b467bddb54cdc9a769ba9737417fbe3d8d5614f62"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "soroban-token-spec"
-version = "25.3.1"
+version = "25.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a7e016becd17190ac5960bc3b591adbec158fda4e739d861b4f63dd8cd337c"
+checksum = "7e9aaafe26a24bcfcbfa57ecce63d694ef245a3469d687a5d084d197b209fab0"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",
@@ -4316,9 +4269,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellar-asset-spec"
-version = "25.3.1"
+version = "25.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c245a68279b5f31fba7ceb3ca2d00a602eabc7055afb8f7a671c886d4b5a94ed"
+checksum = "294e96de0005e69c839405393e123a08ee5ace4bd91d5fbcc8ad33c92cd0497e"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",
@@ -4331,7 +4284,7 @@ version = "0.0.6"
 dependencies = [
  "cargo_metadata",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.17",
  "topological-sort",
 ]
 
@@ -4356,7 +4309,7 @@ dependencies = [
  "stellar-build",
  "stellar-rpc-client",
  "stellar-strkey 0.0.15",
- "thiserror 2.0.18",
+ "thiserror 2.0.17",
  "tokio",
 ]
 
@@ -4384,19 +4337,19 @@ dependencies = [
  "stellar-rpc-client",
  "stellar-scaffold-test",
  "stellar-strkey 0.0.15",
- "thiserror 2.0.18",
+ "thiserror 2.0.17",
  "tokio",
 ]
 
 [[package]]
 name = "stellar-rpc-client"
-version = "25.1.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a72922387b5c3d48f9978795f1c6a81f3b48467951e3073cdd7a93824ba659f"
+checksum = "22c11b19c588a2f46421e142100f8ec38958307a04a16ab34f8c14d23e9b7395"
 dependencies = [
  "clap",
  "hex",
- "http 1.4.0",
+ "http 1.3.1",
  "itertools 0.10.5",
  "jsonrpsee-core",
  "jsonrpsee-http-client",
@@ -4431,7 +4384,7 @@ dependencies = [
  "heck 0.5.0",
  "hex",
  "ignore",
- "indexmap 2.14.0",
+ "indexmap 2.12.0",
  "itertools 0.14.0",
  "mockito",
  "notify",
@@ -4454,11 +4407,11 @@ dependencies = [
  "stellar-xdr 25.0.0",
  "tar",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
- "toml 0.9.12+spec-1.1.0",
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml 0.9.8",
+ "toml_edit 0.23.9",
  "uuid",
  "walkdir",
  "webbrowser",
@@ -4483,7 +4436,7 @@ dependencies = [
  "stellar-build",
  "stellar-strkey 0.0.13",
  "stellar-xdr 23.0.0",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4494,7 +4447,7 @@ dependencies = [
  "serde",
  "serde_json",
  "stellar-scaffold-ext-types",
- "thiserror 2.0.18",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4643,9 +4596,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4669,14 +4622,14 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
 dependencies = [
  "filetime",
  "libc",
@@ -4685,15 +4638,26 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.27.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
- "rustix 1.1.4",
+ "rustix 1.1.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]
@@ -4738,11 +4702,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -4753,18 +4717,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4778,30 +4742,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde_core",
+ "serde",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4828,9 +4792,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4838,9 +4802,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4853,9 +4817,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
  "bytes",
  "libc",
@@ -4863,20 +4827,20 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.1",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4895,15 +4859,15 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls 0.23.35",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4912,9 +4876,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4938,17 +4902,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.12.0",
  "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "serde_spanned 1.0.3",
+ "toml_datetime 0.7.3",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
@@ -4962,18 +4926,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
 dependencies = [
  "serde_core",
 ]
@@ -4984,46 +4939,34 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.12.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.23.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "5d7cbc3b4b49633d57a0509303158ca50de80ae32c265093b24c414705807832"
 dependencies = [
- "indexmap 2.14.0",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "indexmap 2.12.0",
+ "toml_datetime 0.7.3",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
-dependencies = [
- "indexmap 2.14.0",
- "toml_datetime 1.1.1+spec-1.1.0",
- "toml_parser",
- "winnow 1.0.1",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
- "winnow 1.0.1",
+ "winnow",
 ]
 
 [[package]]
@@ -5034,9 +4977,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
 name = "topological-sort"
@@ -5061,9 +5004,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -5076,18 +5019,18 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
- "tower 0.5.3",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -5106,9 +5049,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.44"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -5118,32 +5061,32 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "time",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.31"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.36"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -5162,9 +5105,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.23"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -5203,9 +5146,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.24"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-normalization"
@@ -5218,9 +5161,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -5229,16 +5178,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "unit-prefix"
-version = "0.5.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
 
 [[package]]
 name = "untrusted"
@@ -5248,9 +5191,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.8"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -5272,11 +5215,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -5301,7 +5244,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5340,18 +5283,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
@@ -5364,9 +5298,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5377,19 +5311,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
 dependencies = [
+ "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5397,44 +5334,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.235.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bc393c395cb621367ff02d854179882b9a351b4e0c93d1397e6090b53a5c2a"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.235.0",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -5445,18 +5362,6 @@ checksum = "b854b1461005a7b3365742310f7faa3cac3add809d66928c64a40c7e9e842ebb"
 dependencies = [
  "byteorder 0.5.3",
  "leb128",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -5496,30 +5401,7 @@ version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
- "indexmap 2.14.0",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.235.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
-dependencies = [
- "bitflags 2.11.0",
- "indexmap 2.14.0",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap 2.12.0",
  "semver",
 ]
 
@@ -5534,9 +5416,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5554,9 +5436,9 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.0"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe985f41e291eecef5e5c0770a18d28390addb03331c043964d9e916453d6f16"
+checksum = "00f1243ef785213e3a32fa0396093424a3a6ea566f9948497e5a2309261a4c97"
 dependencies = [
  "core-foundation 0.10.1",
  "jni",
@@ -5570,9 +5452,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5685,7 +5567,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5696,7 +5578,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5731,6 +5613,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -5776,6 +5667,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5837,6 +5743,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -5855,6 +5767,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -5870,6 +5788,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5903,6 +5827,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -5918,6 +5848,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5939,6 +5875,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -5954,6 +5896,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5975,115 +5923,24 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap 2.14.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.244.0",
- "wasm-metadata",
- "wasmparser 0.244.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.244.0",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xattr"
@@ -6092,14 +5949,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.4",
+ "rustix 1.1.2",
 ]
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6108,54 +5965,54 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
  "synstructure",
 ]
 
@@ -6170,20 +6027,20 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -6192,9 +6049,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6203,17 +6060,11 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.110",
 ]
-
-[[package]]
-name = "zmij"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4402,6 +4402,7 @@ dependencies = [
  "stellar-build",
  "stellar-rpc-client",
  "stellar-scaffold-ext-types",
+ "stellar-scaffold-reporter",
  "stellar-scaffold-test",
  "stellar-strkey 0.0.15",
  "stellar-xdr 25.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4449,7 +4449,6 @@ dependencies = [
  "serde_json",
  "stellar-scaffold-ext-types",
  "stellar-scaffold-test",
- "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Scaffold Stellar** is a developer toolkit for building decentralized applications (dApps) and smart contracts on the [**Stellar** blockchain](https://stellar.org).
 
-It helps you go from **idea** to **working full-stack dApp** faster — by providing CLI tools, reusable contract templates, a smart contract registry, and a modern frontend.
+It helps you go from **idea** to **working full-stack dApp** faster by providing CLI tools, reusable contract templates, a smart contract registry, and a modern frontend.
 
 ---
 
@@ -143,6 +143,28 @@ stellar registry install my-contract-instance                           # Instal
 > Use `--help` on any command for usage instructions.
 
 ---
+
+## Extensions
+
+Scaffold Stellar's build pipeline supports extensions by calling binaries on your PATH that tap into lifecycle hooks fired before and after each compile, deploy, codegen, and watch cycle.
+
+The built-in **[Scaffold Reporter](./crates/stellar-scaffold-reporter/)** extension is included in every new project. It logs compile times, WASM sizes, deploy durations, and total build cycle time directly to your console.
+
+Register extensions in `environments.toml`:
+
+```toml
+[development]
+extensions = ["reporter"]
+
+# Optional per-extension config:
+[development.ext.reporter]
+warn_size_kb = 128
+```
+
+See the [Extensions Guide](https://scaffoldstellar.com/docs/extensions) to learn how the hook system works and how to build your own extension.
+
+---
+
 ## Smart Contract Deployment
 
 ### 1. Publish Your Contract
@@ -248,7 +270,7 @@ Ask questions in the repo Discussions tab
 
 Search [DeepWiki](https://deepwiki.org/)
 
-Or just open an issue — we're happy to help!
+Or just open an issue. We're happy to help!
 
 Happy hacking!
 ---

--- a/crates/stellar-scaffold-cli/Cargo.toml
+++ b/crates/stellar-scaffold-cli/Cargo.toml
@@ -74,6 +74,7 @@ fs_extra = "1.3"
 webbrowser = "1.0.6"
 
 [dev-dependencies]
+stellar-scaffold-reporter = { path = "../stellar-scaffold-reporter" }
 assert_cmd = "2.1.1"
 assert_fs = "1.1.3"
 predicates = "3.1.3"

--- a/crates/stellar-scaffold-cli/Cargo.toml
+++ b/crates/stellar-scaffold-cli/Cargo.toml
@@ -74,7 +74,6 @@ fs_extra = "1.3"
 webbrowser = "1.0.6"
 
 [dev-dependencies]
-stellar-scaffold-reporter = { path = "../stellar-scaffold-reporter" }
 assert_cmd = "2.1.1"
 assert_fs = "1.1.3"
 predicates = "3.1.3"

--- a/crates/stellar-scaffold-cli/build.rs
+++ b/crates/stellar-scaffold-cli/build.rs
@@ -1,3 +1,23 @@
 fn main() {
     crate_git_revision::init();
+
+    // cargo_bin!("stellar-scaffold-reporter") in integration tests expands to
+    // env!("CARGO_BIN_EXE_stellar-scaffold-reporter"), which Cargo sets for
+    // same-package binaries and dev-dependency binaries during `cargo test` but
+    // NOT during `cargo clippy --tests`.  Emitting it here ensures it is always
+    // present at compile time regardless of how the crate is being built.
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    // OUT_DIR = target/<profile>/build/<hash>/out — 3 levels up is target/<profile>/
+    let target_dir = std::path::Path::new(&out_dir).ancestors().nth(3).unwrap();
+    let exe_suffix = if cfg!(target_os = "windows") {
+        ".exe"
+    } else {
+        ""
+    };
+    println!(
+        "cargo:rustc-env=CARGO_BIN_EXE_stellar-scaffold-reporter={}",
+        target_dir
+            .join(format!("stellar-scaffold-reporter{exe_suffix}"))
+            .display()
+    );
 }

--- a/crates/stellar-scaffold-cli/src/commands/build/clients.rs
+++ b/crates/stellar-scaffold-cli/src/commands/build/clients.rs
@@ -25,7 +25,7 @@ use stellar_cli::{
     utils::contract_spec::Spec,
 };
 use stellar_scaffold_ext_types::{
-    CodegenContext, CompileContext, DeployContext, HookName, NetworkConfig,
+    CodegenContext, CompileContext, DeployContext, DeployKind, HookName, NetworkConfig,
 };
 use stellar_strkey::{self, Contract};
 use stellar_xdr::curr::ScSpecEntry::FunctionV0;
@@ -236,6 +236,7 @@ impl Builder {
         wasm_path: PathBuf,
         wasm_hash: &str,
         contract_id: Option<String>,
+        deploy_kind: Option<DeployKind>,
     ) -> DeployContext {
         DeployContext {
             compile: self.base_compile_ctx(),
@@ -244,6 +245,7 @@ impl Builder {
             wasm_path,
             wasm_hash: wasm_hash.to_string(),
             contract_id,
+            deploy_kind,
         }
     }
 
@@ -261,6 +263,7 @@ impl Builder {
                 self.get_wasm_path(name),
                 wasm_hash.unwrap_or(""),
                 Some(contract_id.to_string()),
+                None,
             ),
             ts_package_dir,
             src_template_path,
@@ -356,14 +359,12 @@ export default new Client.Client({{
     ) -> Result<(), Error> {
         let network = &self.network;
         let printer = self.printer();
-        printer.infoln(format!("Binding {name:?} contract"));
         let workspace_root = &self.workspace_root;
         let final_output_dir = workspace_root.join(format!("packages/{name}"));
         let src_template_path = workspace_root.join(format!("src/contracts/{name}.ts"));
 
         // Create a temporary directory for building the new client
         let temp_dir = workspace_root.join(format!("target/packages/{name}"));
-        let temp_dir_display = temp_dir.display();
         let config_dir = self.get_config_dir()?;
 
         extension::run_hook(
@@ -398,7 +399,6 @@ export default new Client.Client({{
         bindings_cmd.execute(self.global_args.quiet).await?;
 
         // Run `npm i` in the temp directory
-        printer.infoln(format!("Running 'npm install' in {temp_dir_display:?}"));
         let output = std::process::Command::new(npm_cmd())
             .current_dir(&temp_dir)
             .arg("install")
@@ -418,9 +418,7 @@ export default new Client.Client({{
                 ),
             ));
         }
-        printer.checkln(format!("'npm install' succeeded in {temp_dir_display}"));
 
-        printer.infoln(format!("Running 'npm run build' in {temp_dir_display}"));
         let output = std::process::Command::new(npm_cmd())
             .current_dir(&temp_dir)
             .arg("run")
@@ -440,7 +438,6 @@ export default new Client.Client({{
                 ),
             ));
         }
-        printer.checkln(format!("'npm run build' succeeded in {temp_dir_display}"));
 
         // Now atomically replace the old directory with the new one
         if final_output_dir.exists() {
@@ -613,8 +610,6 @@ export default new Client.Client({{
 
         let names = Self::maintain_user_ordering(&package_names, contracts);
 
-        let mut results: Vec<(String, Result<(), String>)> = Vec::new();
-
         for name in names {
             let settings = contracts
                 .and_then(|contracts| contracts.get(name.as_str()))
@@ -632,29 +627,9 @@ export default new Client.Client({{
             {
                 Ok(()) => {
                     printer.checkln(format!("Successfully generated client for: {name}"));
-                    results.push((name, Ok(())));
                 }
                 Err(e) => {
-                    printer.errorln(format!("Failed to generate client for: {name}"));
-                    results.push((name, Err(e.to_string())));
-                }
-            }
-        }
-
-        // Partition results into successes and failures
-        let (successes, failures): (Vec<_>, Vec<_>) =
-            results.into_iter().partition(|(_, result)| result.is_ok());
-
-        // Print summary
-        printer.infoln("Client Generation Summary:");
-        printer.blankln(format!("Successfully processed: {}", successes.len()));
-        printer.blankln(format!("Failed: {}", failures.len()));
-
-        if !failures.is_empty() {
-            printer.infoln("Failures:");
-            for (name, result) in &failures {
-                if let Err(e) = result {
-                    printer.blankln(format!("{name}: {e}"));
+                    printer.errorln(format!("Failed to generate client for: {name}: {e}"));
                 }
             }
         }
@@ -748,23 +723,23 @@ export default new Client.Client({{
                         )
                         .await?;
                 }
-                printer.infoln(format!("Updating contract {name:?}"));
             }
 
             // Fire pre-deploy hook before the actual deploy
             extension::run_hook(
                 &self.extensions,
                 HookName::PreDeploy,
-                &self.deploy_ctx(name, wasm_path.clone(), &new_hash, None),
+                &self.deploy_ctx(name, wasm_path.clone(), &new_hash, None, None),
                 printer,
             )
             .await;
 
             // Deploy new contract if we got here (don't deploy if we already run an upgrade)
-            let contract_id = if let Some(upgraded) = upgraded_contract {
-                upgraded
+            let (contract_id, deploy_kind) = if let Some(upgraded) = upgraded_contract {
+                (upgraded, DeployKind::Upgraded)
             } else {
-                self.deploy_contract(name, &new_hash, &settings).await?
+                let id = self.deploy_contract(name, &new_hash, &settings).await?;
+                (id, DeployKind::Fresh)
             };
             // Run after_deploy script if in development or test environment
             if let Some(after_deploy) = settings.after_deploy.as_deref()
@@ -780,7 +755,13 @@ export default new Client.Client({{
             extension::run_hook(
                 &self.extensions,
                 HookName::PostDeploy,
-                &self.deploy_ctx(name, wasm_path, &new_hash, Some(contract_id.to_string())),
+                &self.deploy_ctx(
+                    name,
+                    wasm_path,
+                    &new_hash,
+                    Some(contract_id.to_string()),
+                    Some(deploy_kind),
+                ),
                 printer,
             )
             .await;
@@ -796,11 +777,9 @@ export default new Client.Client({{
 
     async fn upload_contract_wasm(
         &self,
-        name: &str,
+        _name: &str,
         wasm_path: &std::path::Path,
     ) -> Result<String, Error> {
-        let printer = self.printer();
-        printer.infoln(format!("Uploading {name:?} wasm bytecode on-chain..."));
         let cmd = cli::contract::upload::Cmd {
             config: self.config(),
             resources: stellar_cli::resources::Args::default(),
@@ -820,7 +799,6 @@ export default new Client.Client({{
             .into_result()
             .expect("no hash returned by 'contract upload'")
             .to_string();
-        printer.infoln(format!("    ↳ hash: {hash}"));
         Ok(hash)
     }
 
@@ -856,7 +834,6 @@ export default new Client.Client({{
         hash: &str,
         settings: &env_toml::Contract,
     ) -> Result<Contract, Error> {
-        let printer = self.printer();
         let source = self.source_account.to_string();
         let mut deploy_args = vec![
             format!("--alias={name}"),
@@ -882,7 +859,6 @@ export default new Client.Client({{
             deploy_args.extend_from_slice(&["--source".to_string(), source]);
         }
 
-        printer.infoln(format!("Instantiating {name:?} smart contract"));
         let deploy_arg_refs: Vec<&str> = deploy_args
             .iter()
             .map(std::string::String::as_str)
@@ -897,7 +873,6 @@ export default new Client.Client({{
             .await?
             .into_result()
             .expect("no contract id returned by 'contract deploy'");
-        printer.infoln(format!("    ↳ contract_id: {contract_id}"));
 
         Ok(contract_id)
     }
@@ -922,9 +897,6 @@ export default new Client.Client({{
             return Ok(None);
         }
 
-        printer
-            .infoln("Upgradable contract found, will use 'upgrade' function instead of redeploy");
-
         let existing_contract_id_str = existing_contract_id.to_string();
         let source = self.source_account.to_string();
         let mut redeploy_args = vec![
@@ -945,7 +917,6 @@ export default new Client.Client({{
         } else {
             cli::contract::invoke::Cmd::parse_arg_vec(&redeploy_args)
         }?;
-        printer.infoln(format!("Upgrading {name:?} smart contract"));
         invoke_cmd
             .execute(
                 &self.config(),
@@ -955,7 +926,6 @@ export default new Client.Client({{
             .await?
             .into_result()
             .expect("no result returned by 'contract invoke'");
-        printer.infoln(format!("Contract upgraded: {existing_contract_id}"));
 
         Ok(Some(existing_contract_id))
     }

--- a/crates/stellar-scaffold-cli/src/commands/build/clients.rs
+++ b/crates/stellar-scaffold-cli/src/commands/build/clients.rs
@@ -31,6 +31,17 @@ use stellar_strkey::{self, Contract};
 use stellar_xdr::curr::ScSpecEntry::FunctionV0;
 use stellar_xdr::curr::{Error as xdrError, ScSpecEntry, ScSpecTypeBytesN, ScSpecTypeDef};
 
+/// Internal decision about what deploy action to take for a contract.
+/// Resolved before `pre-deploy` fires so the hook always has a clean execution context.
+enum DeployDecision {
+    /// No existing alias, or existing contract is not upgradeable — create a new instance.
+    Fresh,
+    /// Existing contract upgraded in-place; the returned ID is unchanged.
+    Upgraded(Contract),
+    /// Existing contract already has the target WASM hash — no on-chain action needed.
+    Unchanged(Contract),
+}
+
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, clap::ValueEnum)]
 pub enum ScaffoldEnv {
     Development,
@@ -356,16 +367,13 @@ export default new Client.Client({{
         name: &str,
         contract_id: &str,
         wasm_hash: Option<&str>,
+        rebuild: bool,
     ) -> Result<(), Error> {
         let network = &self.network;
         let printer = self.printer();
         let workspace_root = &self.workspace_root;
         let final_output_dir = workspace_root.join(format!("packages/{name}"));
         let src_template_path = workspace_root.join(format!("src/contracts/{name}.ts"));
-
-        // Create a temporary directory for building the new client
-        let temp_dir = workspace_root.join(format!("target/packages/{name}"));
-        let config_dir = self.get_config_dir()?;
 
         extension::run_hook(
             &self.extensions,
@@ -381,98 +389,97 @@ export default new Client.Client({{
         )
         .await;
 
-        let bindings_cmd = cli::contract::bindings::typescript::Cmd::parse_arg_vec(&[
-            "--contract-id",
-            contract_id,
-            "--output-dir",
-            temp_dir.to_str().expect("we do not support non-utf8 paths"),
-            "--config-dir",
-            config_dir
-                .to_str()
-                .expect("we do not support non-utf8 paths"),
-            "--overwrite",
-            "--rpc-url",
-            &network.rpc_url,
-            "--network-passphrase",
-            &network.network_passphrase,
-        ])?;
-        bindings_cmd.execute(self.global_args.quiet).await?;
+        if rebuild {
+            let temp_dir = workspace_root.join(format!("target/packages/{name}"));
+            let config_dir = self.get_config_dir()?;
 
-        // Run `npm i` in the temp directory
-        let output = std::process::Command::new(npm_cmd())
-            .current_dir(&temp_dir)
-            .arg("install")
-            .arg("--loglevel=error") // Reduce noise from warnings
-            .arg("--no-workspaces") // fix issue where stellar sometimes isnt installed locally causing tsc to fail
-            .output()?;
+            let bindings_cmd = cli::contract::bindings::typescript::Cmd::parse_arg_vec(&[
+                "--contract-id",
+                contract_id,
+                "--output-dir",
+                temp_dir.to_str().expect("we do not support non-utf8 paths"),
+                "--config-dir",
+                config_dir
+                    .to_str()
+                    .expect("we do not support non-utf8 paths"),
+                "--overwrite",
+                "--rpc-url",
+                &network.rpc_url,
+                "--network-passphrase",
+                &network.network_passphrase,
+            ])?;
+            bindings_cmd.execute(self.global_args.quiet).await?;
 
-        if !output.status.success() {
-            // Clean up temp directory on failure
-            let _ = std::fs::remove_dir_all(&temp_dir);
-            return Err(Error::NpmCommandFailure(
-                temp_dir.clone(),
-                format!(
-                    "npm install failed with status: {:?}\nError: {}",
-                    output.status.code(),
-                    String::from_utf8_lossy(&output.stderr)
-                ),
-            ));
-        }
-
-        let output = std::process::Command::new(npm_cmd())
-            .current_dir(&temp_dir)
-            .arg("run")
-            .arg("build")
-            .arg("--loglevel=error") // Reduce noise from warnings
-            .output()?;
-
-        if !output.status.success() {
-            // Clean up temp directory on failure
-            let _ = std::fs::remove_dir_all(&temp_dir);
-            return Err(Error::NpmCommandFailure(
-                temp_dir.clone(),
-                format!(
-                    "npm run build failed with status: {:?}\nError: {}",
-                    output.status.code(),
-                    String::from_utf8_lossy(&output.stderr)
-                ),
-            ));
-        }
-
-        // Now atomically replace the old directory with the new one
-        if final_output_dir.exists() {
-            for p in ["dist/index.d.ts", "dist/index.js", "src/index.ts"]
-                .iter()
-                .map(Path::new)
-            {
-                std::fs::copy(temp_dir.join(p), final_output_dir.join(p))?;
-            }
-            printer.checkln(format!("Client {name:?} updated successfully"));
-        } else {
-            std::fs::create_dir_all(&final_output_dir)?;
-            // No existing directory, just move temp to final location
-            std::fs::rename(&temp_dir, &final_output_dir)?;
-            printer.checkln(format!("Client {name:?} created successfully"));
-            // Run npm install in the final output directory to ensure proper linking
             let output = std::process::Command::new(npm_cmd())
-                .current_dir(&final_output_dir)
+                .current_dir(&temp_dir)
                 .arg("install")
-                .arg("--loglevel=error")
+                .arg("--loglevel=error") // Reduce noise from warnings
+                .arg("--no-workspaces") // fix issue where stellar sometimes isnt installed locally causing tsc to fail
                 .output()?;
 
             if !output.status.success() {
+                let _ = std::fs::remove_dir_all(&temp_dir);
                 return Err(Error::NpmCommandFailure(
-                    final_output_dir.clone(),
+                    temp_dir.clone(),
                     format!(
-                        "npm install in final directory failed with status: {:?}\nError: {}",
+                        "npm install failed with status: {:?}\nError: {}",
                         output.status.code(),
                         String::from_utf8_lossy(&output.stderr)
                     ),
                 ));
             }
-        }
 
-        self.create_contract_template(name, contract_id, network)?;
+            let output = std::process::Command::new(npm_cmd())
+                .current_dir(&temp_dir)
+                .arg("run")
+                .arg("build")
+                .arg("--loglevel=error") // Reduce noise from warnings
+                .output()?;
+
+            if !output.status.success() {
+                let _ = std::fs::remove_dir_all(&temp_dir);
+                return Err(Error::NpmCommandFailure(
+                    temp_dir.clone(),
+                    format!(
+                        "npm run build failed with status: {:?}\nError: {}",
+                        output.status.code(),
+                        String::from_utf8_lossy(&output.stderr)
+                    ),
+                ));
+            }
+
+            if final_output_dir.exists() {
+                for p in ["dist/index.d.ts", "dist/index.js", "src/index.ts"]
+                    .iter()
+                    .map(Path::new)
+                {
+                    std::fs::copy(temp_dir.join(p), final_output_dir.join(p))?;
+                }
+                printer.checkln(format!("Client {name:?} updated successfully"));
+            } else {
+                std::fs::create_dir_all(&final_output_dir)?;
+                std::fs::rename(&temp_dir, &final_output_dir)?;
+                printer.checkln(format!("Client {name:?} created successfully"));
+                let output = std::process::Command::new(npm_cmd())
+                    .current_dir(&final_output_dir)
+                    .arg("install")
+                    .arg("--loglevel=error")
+                    .output()?;
+
+                if !output.status.success() {
+                    return Err(Error::NpmCommandFailure(
+                        final_output_dir.clone(),
+                        format!(
+                            "npm install in final directory failed with status: {:?}\nError: {}",
+                            output.status.code(),
+                            String::from_utf8_lossy(&output.stderr)
+                        ),
+                    ));
+                }
+            }
+
+            self.create_contract_template(name, contract_id, network)?;
+        }
 
         extension::run_hook(
             &self.extensions,
@@ -583,7 +590,8 @@ export default new Client.Client({{
                 if stellar_strkey::Contract::from_string(id).is_err() {
                     return Err(Error::InvalidContractID(id.to_string()));
                 }
-                self.generate_contract_bindings(name, id, None).await?;
+                self.generate_contract_bindings(name, id, None, true)
+                    .await?;
             } else {
                 return Err(Error::MissingContractID(name.to_string()));
             }
@@ -664,14 +672,6 @@ export default new Client.Client({{
         Ok(())
     }
 
-    fn get_package_dir(&self, name: &str) -> Result<std::path::PathBuf, Error> {
-        let package_dir = self.workspace_root.join(format!("packages/{name}"));
-        if !package_dir.exists() {
-            return Err(Error::BadContractName(name.to_string()));
-        }
-        Ok(package_dir)
-    }
-
     async fn process_single_contract(
         &self,
         name: &str,
@@ -680,52 +680,48 @@ export default new Client.Client({{
         env: ScaffoldEnv,
     ) -> Result<(), Error> {
         let printer = self.printer();
-        // First check if we have an ID in settings.
-        // Returns (contract_id, wasm_hash) — wasm_hash is None for pinned-ID contracts.
-        let (contract_id, wasm_hash) = if let Some(id) = &settings.id {
+        // Returns (contract_id, wasm_hash, needs_rebuild).
+        // wasm_hash is None for pinned-ID contracts; needs_rebuild is always true for them.
+        let (contract_id, wasm_hash, needs_rebuild) = if let Some(id) = &settings.id {
             let contract_id =
                 Contract::from_string(id).map_err(|_| Error::InvalidContractID(id.clone()))?;
-            (contract_id, None::<String>)
+            (contract_id, None::<String>, true)
         } else {
             let wasm_path = self.get_wasm_path(name);
             if !wasm_path.exists() {
                 return Err(Error::BadContractName(name.to_string()));
             }
             let new_hash = self.upload_contract_wasm(name, &wasm_path).await?;
-            let mut upgraded_contract = None;
 
-            // Check existing alias - if it exists and matches hash, we can return early
-            if let Some(existing_contract_id) = self.get_contract_alias(name, network)? {
-                let hash = self
-                    .get_contract_hash(&existing_contract_id, network)
-                    .await?;
+            // Determine what deploy action is needed before firing any hooks.
+            let decision = if let Some(existing_id) = self.get_contract_alias(name, network)? {
+                let hash = self.get_contract_hash(&existing_id, network).await?;
                 if let Some(current_hash) = hash {
                     if current_hash == new_hash {
                         printer.checkln(format!("Contract {name:?} is up to date"));
-                        // If there is not a package at packages/<name>, generate bindings
-                        if self.get_package_dir(name).is_err() {
-                            self.generate_contract_bindings(
+                        DeployDecision::Unchanged(existing_id)
+                    } else {
+                        match self
+                            .try_upgrade_contract(
                                 name,
-                                &existing_contract_id.to_string(),
-                                Some(&new_hash),
+                                existing_id,
+                                &current_hash,
+                                &new_hash,
+                                network,
                             )
-                            .await?;
+                            .await?
+                        {
+                            Some(upgraded_id) => DeployDecision::Upgraded(upgraded_id),
+                            None => DeployDecision::Fresh,
                         }
-                        return Ok(());
                     }
-                    upgraded_contract = self
-                        .try_upgrade_contract(
-                            name,
-                            existing_contract_id,
-                            &current_hash,
-                            &new_hash,
-                            network,
-                        )
-                        .await?;
+                } else {
+                    DeployDecision::Fresh
                 }
-            }
+            } else {
+                DeployDecision::Fresh
+            };
 
-            // Fire pre-deploy hook before the actual deploy
             extension::run_hook(
                 &self.extensions,
                 HookName::PreDeploy,
@@ -734,24 +730,27 @@ export default new Client.Client({{
             )
             .await;
 
-            // Deploy new contract if we got here (don't deploy if we already run an upgrade)
-            let (contract_id, deploy_kind) = if let Some(upgraded) = upgraded_contract {
-                (upgraded, DeployKind::Upgraded)
-            } else {
-                let id = self.deploy_contract(name, &new_hash, &settings).await?;
-                (id, DeployKind::Fresh)
+            let (contract_id, deploy_kind) = match decision {
+                DeployDecision::Unchanged(id) => (id, DeployKind::Unchanged),
+                DeployDecision::Upgraded(id) => (id, DeployKind::Upgraded),
+                DeployDecision::Fresh => {
+                    let id = self.deploy_contract(name, &new_hash, &settings).await?;
+                    (id, DeployKind::Fresh)
+                }
             };
-            // Run after_deploy script if in development or test environment
-            if let Some(after_deploy) = settings.after_deploy.as_deref()
-                && (env == ScaffoldEnv::Development || env == ScaffoldEnv::Testing)
-            {
-                printer.infoln(format!("Running after_deploy script for {name:?}"));
-                self.run_after_deploy_script(name, &contract_id, after_deploy)
-                    .await?;
-            }
-            self.save_contract_alias(name, &contract_id, network)?;
 
-            // Fire post-deploy hook after the contract ID is confirmed.
+            // Run after_deploy script and save alias only when something changed on-chain.
+            if deploy_kind != DeployKind::Unchanged {
+                if let Some(after_deploy) = settings.after_deploy.as_deref()
+                    && (env == ScaffoldEnv::Development || env == ScaffoldEnv::Testing)
+                {
+                    printer.infoln(format!("Running after_deploy script for {name:?}"));
+                    self.run_after_deploy_script(name, &contract_id, after_deploy)
+                        .await?;
+                }
+                self.save_contract_alias(name, &contract_id, network)?;
+            }
+
             extension::run_hook(
                 &self.extensions,
                 HookName::PostDeploy,
@@ -760,17 +759,27 @@ export default new Client.Client({{
                     wasm_path,
                     &new_hash,
                     Some(contract_id.to_string()),
-                    Some(deploy_kind),
+                    Some(deploy_kind.clone()),
                 ),
                 printer,
             )
             .await;
 
-            (contract_id, Some(new_hash))
+            let needs_rebuild = deploy_kind != DeployKind::Unchanged
+                || !self
+                    .workspace_root
+                    .join(format!("packages/{name}"))
+                    .exists();
+            (contract_id, Some(new_hash), needs_rebuild)
         };
 
-        self.generate_contract_bindings(name, &contract_id.to_string(), wasm_hash.as_deref())
-            .await?;
+        self.generate_contract_bindings(
+            name,
+            &contract_id.to_string(),
+            wasm_hash.as_deref(),
+            needs_rebuild,
+        )
+        .await?;
 
         Ok(())
     }

--- a/crates/stellar-scaffold-cli/src/commands/build/clients.rs
+++ b/crates/stellar-scaffold-cli/src/commands/build/clients.rs
@@ -138,6 +138,10 @@ pub enum Error {
     Json(#[from] serde_json::Error),
     #[error("⛔ ️Failed to run npm command in {0:?}: {1:?}")]
     NpmCommandFailure(std::path::PathBuf, String),
+    #[error("⛔ ️Codegen step for {0:?} failed: {1}")]
+    CodegenStepFailed(String, String),
+    #[error("⛔ ️Client generation failed for {0} contract(s) — see errors above")]
+    ContractClientFailures(usize),
     #[error(transparent)]
     AccountFund(#[from] cli::keys::fund::Error),
     #[error("Failed to get upgrade operator: {0:?}")]
@@ -389,98 +393,110 @@ export default new Client.Client({{
         )
         .await;
 
-        if rebuild {
-            let temp_dir = workspace_root.join(format!("target/packages/{name}"));
-            let config_dir = self.get_config_dir()?;
+        // Convert any inner error to a String *before* the PostCodegen await:
+        // `Error` is not `Send` (some upstream variants wrap non-Send types),
+        // and futures spawned via `tokio::spawn` (see commands/watch/mod.rs)
+        // require everything held across an await to be Send.
+        let codegen_failure: Option<String> = async {
+            if rebuild {
+                let temp_dir = workspace_root.join(format!("target/packages/{name}"));
+                let config_dir = self.get_config_dir()?;
 
-            let bindings_cmd = cli::contract::bindings::typescript::Cmd::parse_arg_vec(&[
-                "--contract-id",
-                contract_id,
-                "--output-dir",
-                temp_dir.to_str().expect("we do not support non-utf8 paths"),
-                "--config-dir",
-                config_dir
-                    .to_str()
-                    .expect("we do not support non-utf8 paths"),
-                "--overwrite",
-                "--rpc-url",
-                &network.rpc_url,
-                "--network-passphrase",
-                &network.network_passphrase,
-            ])?;
-            bindings_cmd.execute(self.global_args.quiet).await?;
+                let bindings_cmd = cli::contract::bindings::typescript::Cmd::parse_arg_vec(&[
+                    "--contract-id",
+                    contract_id,
+                    "--output-dir",
+                    temp_dir.to_str().expect("we do not support non-utf8 paths"),
+                    "--config-dir",
+                    config_dir
+                        .to_str()
+                        .expect("we do not support non-utf8 paths"),
+                    "--overwrite",
+                    "--rpc-url",
+                    &network.rpc_url,
+                    "--network-passphrase",
+                    &network.network_passphrase,
+                ])?;
+                bindings_cmd.execute(self.global_args.quiet).await?;
 
-            let output = std::process::Command::new(npm_cmd())
-                .current_dir(&temp_dir)
-                .arg("install")
-                .arg("--loglevel=error") // Reduce noise from warnings
-                .arg("--no-workspaces") // fix issue where stellar sometimes isnt installed locally causing tsc to fail
-                .output()?;
-
-            if !output.status.success() {
-                let _ = std::fs::remove_dir_all(&temp_dir);
-                return Err(Error::NpmCommandFailure(
-                    temp_dir.clone(),
-                    format!(
-                        "npm install failed with status: {:?}\nError: {}",
-                        output.status.code(),
-                        String::from_utf8_lossy(&output.stderr)
-                    ),
-                ));
-            }
-
-            let output = std::process::Command::new(npm_cmd())
-                .current_dir(&temp_dir)
-                .arg("run")
-                .arg("build")
-                .arg("--loglevel=error") // Reduce noise from warnings
-                .output()?;
-
-            if !output.status.success() {
-                let _ = std::fs::remove_dir_all(&temp_dir);
-                return Err(Error::NpmCommandFailure(
-                    temp_dir.clone(),
-                    format!(
-                        "npm run build failed with status: {:?}\nError: {}",
-                        output.status.code(),
-                        String::from_utf8_lossy(&output.stderr)
-                    ),
-                ));
-            }
-
-            if final_output_dir.exists() {
-                for p in ["dist/index.d.ts", "dist/index.js", "src/index.ts"]
-                    .iter()
-                    .map(Path::new)
-                {
-                    std::fs::copy(temp_dir.join(p), final_output_dir.join(p))?;
-                }
-                printer.checkln(format!("Client {name:?} updated successfully"));
-            } else {
-                std::fs::create_dir_all(&final_output_dir)?;
-                std::fs::rename(&temp_dir, &final_output_dir)?;
-                printer.checkln(format!("Client {name:?} created successfully"));
                 let output = std::process::Command::new(npm_cmd())
-                    .current_dir(&final_output_dir)
+                    .current_dir(&temp_dir)
                     .arg("install")
-                    .arg("--loglevel=error")
+                    .arg("--loglevel=error") // Reduce noise from warnings
+                    .arg("--no-workspaces") // fix issue where stellar sometimes isnt installed locally causing tsc to fail
                     .output()?;
 
                 if !output.status.success() {
+                    let _ = std::fs::remove_dir_all(&temp_dir);
                     return Err(Error::NpmCommandFailure(
-                        final_output_dir.clone(),
+                        temp_dir.clone(),
                         format!(
-                            "npm install in final directory failed with status: {:?}\nError: {}",
+                            "npm install failed with status: {:?}\nError: {}",
                             output.status.code(),
                             String::from_utf8_lossy(&output.stderr)
                         ),
                     ));
                 }
+
+                let output = std::process::Command::new(npm_cmd())
+                    .current_dir(&temp_dir)
+                    .arg("run")
+                    .arg("build")
+                    .arg("--loglevel=error") // Reduce noise from warnings
+                    .output()?;
+
+                if !output.status.success() {
+                    let _ = std::fs::remove_dir_all(&temp_dir);
+                    return Err(Error::NpmCommandFailure(
+                        temp_dir.clone(),
+                        format!(
+                            "npm run build failed with status: {:?}\nError: {}",
+                            output.status.code(),
+                            String::from_utf8_lossy(&output.stderr)
+                        ),
+                    ));
+                }
+
+                if final_output_dir.exists() {
+                    for p in ["dist/index.d.ts", "dist/index.js", "src/index.ts"]
+                        .iter()
+                        .map(Path::new)
+                    {
+                        std::fs::copy(temp_dir.join(p), final_output_dir.join(p))?;
+                    }
+                    printer.checkln(format!("Client {name:?} updated successfully"));
+                } else {
+                    std::fs::create_dir_all(&final_output_dir)?;
+                    std::fs::rename(&temp_dir, &final_output_dir)?;
+                    printer.checkln(format!("Client {name:?} created successfully"));
+                    let output = std::process::Command::new(npm_cmd())
+                        .current_dir(&final_output_dir)
+                        .arg("install")
+                        .arg("--loglevel=error")
+                        .output()?;
+
+                    if !output.status.success() {
+                        return Err(Error::NpmCommandFailure(
+                            final_output_dir.clone(),
+                            format!(
+                                "npm install in final directory failed with status: {:?}\nError: {}",
+                                output.status.code(),
+                                String::from_utf8_lossy(&output.stderr)
+                            ),
+                        ));
+                    }
+                }
+
+                self.create_contract_template(name, contract_id, network)?;
             }
-
-            self.create_contract_template(name, contract_id, network)?;
+            Ok::<(), Error>(())
         }
+        .await
+        .err()
+        .map(|e| e.to_string());
 
+        // Fire PostCodegen unconditionally so hook consumers see a consistent
+        // lifecycle even when an inner step errored.
         extension::run_hook(
             &self.extensions,
             HookName::PostCodegen,
@@ -495,6 +511,9 @@ export default new Client.Client({{
         )
         .await;
 
+        if let Some(msg) = codegen_failure {
+            return Err(Error::CodegenStepFailed(name.to_string(), msg));
+        }
         Ok(())
     }
 
@@ -618,6 +637,7 @@ export default new Client.Client({{
 
         let names = Self::maintain_user_ordering(&package_names, contracts);
 
+        let mut failures = 0usize;
         for name in names {
             let settings = contracts
                 .and_then(|contracts| contracts.get(name.as_str()))
@@ -638,10 +658,14 @@ export default new Client.Client({{
                 }
                 Err(e) => {
                     printer.errorln(format!("Failed to generate client for: {name}: {e}"));
+                    failures += 1;
                 }
             }
         }
 
+        if failures > 0 {
+            return Err(Error::ContractClientFailures(failures));
+        }
         Ok(())
     }
 

--- a/crates/stellar-scaffold-cli/src/commands/build/clients.rs
+++ b/crates/stellar-scaffold-cli/src/commands/build/clients.rs
@@ -140,8 +140,6 @@ pub enum Error {
     NpmCommandFailure(std::path::PathBuf, String),
     #[error("⛔ ️Codegen step for {0:?} failed: {1}")]
     CodegenStepFailed(String, String),
-    #[error("⛔ ️Client generation failed for {0} contract(s) — see errors above")]
-    ContractClientFailures(usize),
     #[error(transparent)]
     AccountFund(#[from] cli::keys::fund::Error),
     #[error("Failed to get upgrade operator: {0:?}")]
@@ -637,7 +635,6 @@ export default new Client.Client({{
 
         let names = Self::maintain_user_ordering(&package_names, contracts);
 
-        let mut failures = 0usize;
         for name in names {
             let settings = contracts
                 .and_then(|contracts| contracts.get(name.as_str()))
@@ -658,14 +655,10 @@ export default new Client.Client({{
                 }
                 Err(e) => {
                     printer.errorln(format!("Failed to generate client for: {name}: {e}"));
-                    failures += 1;
                 }
             }
         }
 
-        if failures > 0 {
-            return Err(Error::ContractClientFailures(failures));
-        }
         Ok(())
     }
 

--- a/crates/stellar-scaffold-cli/src/commands/build/clients.rs
+++ b/crates/stellar-scaffold-cli/src/commands/build/clients.rs
@@ -220,6 +220,7 @@ impl Builder {
         self.compile_ctx.clone().unwrap_or_else(|| {
             let target = self.workspace_root.join("target");
             CompileContext {
+                config: None,
                 project_root: self.workspace_root.clone(),
                 env: self.scaffold_env.to_string(),
                 wasm_out_dir: stellar_build::deps::stellar_wasm_out_dir(&target),

--- a/crates/stellar-scaffold-cli/src/commands/build/mod.rs
+++ b/crates/stellar-scaffold-cli/src/commands/build/mod.rs
@@ -128,7 +128,6 @@ impl Command {
             }
             _ => vec![],
         };
-
         // Build pre-compile context (wasm_paths is empty before compilation).
         let wasm_out_dir =
             self.build.out_dir.clone().unwrap_or_else(|| {
@@ -140,6 +139,7 @@ impl Command {
             .map(|p| p.as_std_path().to_path_buf())
             .collect();
         let pre_compile_ctx = CompileContext {
+            config: None,
             project_root: workspace_root.to_path_buf(),
             env: scaffold_env.to_string(),
             wasm_out_dir: wasm_out_dir.clone(),
@@ -169,6 +169,7 @@ impl Command {
             })
             .collect();
         let post_compile_ctx = CompileContext {
+            config: None,
             project_root: workspace_root.to_path_buf(),
             env: scaffold_env.to_string(),
             wasm_out_dir,

--- a/crates/stellar-scaffold-cli/src/commands/watch/mod.rs
+++ b/crates/stellar-scaffold-cli/src/commands/watch/mod.rs
@@ -159,7 +159,6 @@ impl Cmd {
         } else {
             extension::discover(&current_env.extensions, &printer)
         };
-
         let all_packages = self.build_cmd.list_packages(metadata)?;
         let packages: Vec<PathBuf> = all_packages
             .iter()
@@ -203,6 +202,7 @@ impl Cmd {
             .chain(packages.iter().cloned())
             .collect();
         let project_ctx = ProjectContext {
+            config: None,
             project_root: workspace_root.to_path_buf(),
             env: scaffold_env.to_string(),
             wasm_out_dir: stellar_build::deps::stellar_wasm_out_dir(target_dir),

--- a/crates/stellar-scaffold-cli/src/extension.rs
+++ b/crates/stellar-scaffold-cli/src/extension.rs
@@ -34,9 +34,10 @@ pub fn discover(entries: &[ExtensionEntry], printer: &Print) -> Vec<ResolvedExte
 /// Runs a single lifecycle hook across all registered extensions.
 ///
 /// For each extension whose manifest lists `hook`, spawns
-/// `stellar-scaffold-<name> <hook>` as a subprocess, serializes `context` as
-/// JSON to its stdin, waits for it to exit, then forwards its stdout to
-/// Scaffold's own stdout.
+/// `stellar-scaffold-<name> <hook>` as a subprocess, serializes `context`
+/// as JSON with `config` injected from the extension's entry in
+/// `environments.toml`, writes the result to stdin, waits for it to exit,
+/// then forwards its stdout to Scaffold's own stdout.
 ///
 /// Non-zero exits are logged as errors but do not abort the loop — all
 /// extensions are given a chance to run regardless of whether an earlier one
@@ -49,9 +50,10 @@ pub async fn run_hook<C: serde::Serialize>(
 ) {
     let hook_str = hook.as_str();
 
-    // Serialize once; every extension for this hook receives identical JSON.
-    let context_json = match serde_json::to_vec(context) {
-        Ok(json) => json,
+    // Serialize context to a Value once; per-extension config is injected
+    // into the object before writing to each extension's stdin.
+    let ctx_value = match serde_json::to_value(context) {
+        Ok(v) => v,
         Err(e) => {
             printer.errorln(format!(
                 "Extension hook {hook_str:?}: failed to serialize context: {e}"
@@ -64,6 +66,17 @@ pub async fn run_hook<C: serde::Serialize>(
         if !ext.manifest.hooks.iter().any(|h| h == hook_str) {
             continue;
         }
+
+        let input_json = match inject_config(&ctx_value, ext.config.as_ref()) {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                printer.errorln(format!(
+                    "Extension {:?} hook {hook_str:?}: failed to serialize input: {e}",
+                    ext.name
+                ));
+                continue;
+            }
+        };
 
         let binary_name = binary_name(&ext.name);
 
@@ -85,11 +98,11 @@ pub async fn run_hook<C: serde::Serialize>(
             }
         };
 
-        // Write context JSON then shut down stdin so the child sees EOF.
+        // Write input JSON then shut down stdin so the child sees EOF.
         // Dropping without shutdown() could leave the pipe open on some
         // platforms, causing the child to block waiting for more input.
         if let Some(mut stdin) = child.stdin.take() {
-            if let Err(e) = stdin.write_all(&context_json).await {
+            if let Err(e) = stdin.write_all(&input_json).await {
                 printer.errorln(format!(
                     "Extension {:?} hook {hook_str:?}: failed to write context \
                      to stdin: {e}",
@@ -130,6 +143,27 @@ pub async fn run_hook<C: serde::Serialize>(
             // Continue — give remaining extensions a chance to run.
         }
     }
+}
+
+/// Injects `config` into a serialized context value and returns the combined
+/// JSON bytes written to an extension's stdin.
+///
+/// `ctx` must be a JSON object (the output of serializing any context type).
+/// The `config` key is set to the extension's config value, or `null` if the
+/// extension has no config entry in `environments.toml`.
+fn inject_config(
+    ctx: &serde_json::Value,
+    config: Option<&serde_json::Value>,
+) -> Result<Vec<u8>, serde_json::Error> {
+    let mut map = match ctx {
+        serde_json::Value::Object(m) => m.clone(),
+        _ => serde_json::Map::new(),
+    };
+    map.insert(
+        "config".to_string(),
+        config.cloned().unwrap_or(serde_json::Value::Null),
+    );
+    serde_json::to_vec(&serde_json::Value::Object(map))
 }
 
 /// The resolved status of a single extension entry, used by `ext ls`.
@@ -456,14 +490,13 @@ mod tests {
         struct Ctx {
             env: String,
         }
-        let ext = make_resolved(
+        let exts = vec![make_resolved(
             "reporter",
             dir.path().join(binary_name("reporter")),
             &["post-compile"],
-        );
-
+        )];
         run_hook(
-            &[ext],
+            &exts,
             HookName::PostCompile,
             &Ctx {
                 env: "development".to_owned(),
@@ -483,14 +516,13 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         // Script creates a sentinel file when invoked.
         make_script(&dir, "reporter", r#"touch "$(dirname "$0")/was_invoked""#);
-        let ext = make_resolved(
+        let exts = vec![make_resolved(
             "reporter",
             dir.path().join(binary_name("reporter")),
             &["post-compile"], // registered for post-compile, not post-deploy
-        );
-
+        )];
         run_hook(
-            &[ext],
+            &exts,
             HookName::PostDeploy,
             &serde_json::json!({}),
             &printer(),

--- a/crates/stellar-scaffold-cli/tests/it/build_clients/contracts.rs
+++ b/crates/stellar-scaffold-cli/tests/it/build_clients/contracts.rs
@@ -39,9 +39,7 @@ soroban_token_contract.client = false
         assert!(stderr.contains(format!("Using network at {}\n", rpc_url()).as_str()));
 
         for c in contracts {
-            assert!(stderr.contains(&format!("Uploading \"{c}\" wasm bytecode on-chain")));
-            assert!(stderr.contains(&format!("Instantiating \"{c}\" smart contract")));
-            assert!(stderr.contains(&format!("Binding \"{c}\" contract")));
+            assert!(stderr.contains(&format!("Successfully generated client for: {c}")));
 
             // check that contracts are actually deployed, bound, and imported
             assert!(env.cwd.join(format!("packages/{c}")).exists());
@@ -89,12 +87,9 @@ soroban_token_contract.client = false
         let stderr = env.scaffold("build").assert().success().stderr_as_str();
         println!("{stderr}");
         assert!(stderr.contains("Creating keys for \"alice\"\n"));
-        // assert!(stderr.contains(&format!("Using network at {}\n", rpc_url())));
 
         for c in contracts {
-            assert!(stderr.contains(&format!("Uploading \"{c}\" wasm bytecode on-chain")));
-            assert!(stderr.contains(&format!("Instantiating \"{c}\" smart contract")));
-            assert!(stderr.contains(&format!("Binding \"{c}\" contract")));
+            assert!(stderr.contains(&format!("Successfully generated client for: {c}")));
 
             // check that contracts are actually deployed, bound, and imported
             assert!(env.cwd.join(format!("packages/{c}")).exists());
@@ -165,7 +160,7 @@ soroban_token_contract.client = false
         assert!(output.status.success());
         assert!(
             String::from_utf8_lossy(&output.stderr)
-                .contains("Binding \"soroban_hello_world_contract\" contract")
+                .contains("Successfully generated client for: soroban_hello_world_contract")
         );
 
         let output2 = env
@@ -189,9 +184,17 @@ soroban_token_contract.client = false
         // ensure contract hash change check works, should update in dev mode
         assert!(output3.status.success());
         let message = String::from_utf8_lossy(&output3.stderr);
-        assert!(message.contains("Updating contract \"soroban_hello_world_contract\""));
-        let Some(contract_id) = extract_contract_id(&message) else {
-            panic!("Could not find contract ID in stderr");
+        assert!(
+            message.contains("Successfully generated client for: soroban_hello_world_contract")
+        );
+
+        // Extract the contract ID from the generated TypeScript client file.
+        let ts_file = env
+            .cwd
+            .join("src/contracts/soroban_hello_world_contract.ts");
+        let ts_content = std::fs::read_to_string(&ts_file).expect("TS client file not found");
+        let Some(contract_id) = extract_contract_id_from_ts(&ts_content) else {
+            panic!("Could not find contract ID in generated TS file");
         };
         env.set_environments_toml(format!(
             r#"
@@ -245,14 +248,16 @@ soroban_token_contract.client = false
     });
 }
 
-fn extract_contract_id(stderr: &str) -> Option<String> {
-    stderr
+/// Extracts the contract ID from the `contractId: '...'` line in a generated
+/// TypeScript client file produced by `create_contract_template`.
+fn extract_contract_id_from_ts(content: &str) -> Option<String> {
+    content
         .lines()
-        .find(|line| line.contains("contract_id:"))
-        .and_then(|line| {
-            line.split_whitespace()
-                .last()
-                .map(|id| id.trim().to_string())
+        .find(|l| l.contains("contractId:"))
+        .and_then(|l| {
+            let start = l.find('\'')? + 1;
+            let end = l.rfind('\'')?;
+            (start < end).then(|| l[start..end].to_string())
         })
 }
 
@@ -286,10 +291,7 @@ soroban_token_contract.client = false
         .expect("Failed to execute command");
     let stderr = String::from_utf8_lossy(&output.stderr);
     eprintln!("{stderr}");
-    assert!(stderr.contains("Uploading \"soroban_hello_world_contract\" wasm bytecode on-chain"));
-    assert!(stderr.contains("Instantiating \"soroban_hello_world_contract\" smart contract"));
-    assert!(stderr.contains("Simulating deploy transaction"));
-    assert!(stderr.contains("Binding \"soroban_hello_world_contract\" contract"));
+    assert!(stderr.contains("Successfully generated client for: soroban_hello_world_contract"));
 
     // Switch to a new directory
 
@@ -322,10 +324,7 @@ soroban_token_contract.client = false
         .expect("Failed to execute command");
     let stderr = String::from_utf8_lossy(&output.stderr);
     eprintln!("{stderr}");
-    assert!(stderr.contains("Uploading \"soroban_hello_world_contract\" wasm bytecode on-chain"));
-    assert!(stderr.contains("Instantiating \"soroban_hello_world_contract\" smart contract"));
-    assert!(stderr.contains("Simulating deploy transaction"));
-    assert!(stderr.contains("Binding \"soroban_hello_world_contract\" contract"));
+    assert!(stderr.contains("Successfully generated client for: soroban_hello_world_contract"));
     // Check that the contract files are created in the new directory
     assert!(
         env.cwd
@@ -374,11 +373,7 @@ soroban_token_contract.client = false
 
         assert!(stderr.contains("Creating keys for \"alice\"\n"));
         assert!(stderr.contains(&format!("Using network at {}\n", rpc_url())));
-        assert!(
-            stderr.contains("Uploading \"soroban_hello_world_contract\" wasm bytecode on-chain")
-        );
-        assert!(stderr.contains("Instantiating \"soroban_hello_world_contract\" smart contract"));
-        assert!(stderr.contains("Binding \"soroban_hello_world_contract\" contract"));
+        assert!(stderr.contains("Successfully generated client for: soroban_hello_world_contract"));
 
         // Check that WASM file was copied to custom out_dir
         assert!(out_dir.join("soroban_hello_world_contract.wasm").exists());
@@ -466,23 +461,15 @@ STELLAR_ACCOUNT=bob --symbol ABND --decimal 7 --name abundance --admin bb
         let stderr = env.scaffold("build").assert().success().stderr_as_str();
         eprintln!("{stderr}");
 
-        // Should show summary of results
-        assert!(stderr.contains("Client Generation Summary:"));
-        assert!(stderr.contains("Successfully processed: 3"));
-        assert!(stderr.contains("Failed: 1"));
-        assert!(stderr.contains("Failures:"));
-
-        // Should show specific failure details for token contract
-        assert!(stderr.contains("soroban_token_contract:"));
-
-        // Should still process successful contracts
+        // Successful contracts should produce a client
+        assert!(stderr.contains("Successfully generated client for: soroban_hello_world_contract"));
+        assert!(stderr.contains("Successfully generated client for: soroban_increment_contract"));
         assert!(
-            stderr.contains("Uploading \"soroban_hello_world_contract\" wasm bytecode on-chain")
+            stderr.contains("Successfully generated client for: soroban_custom_types_contract")
         );
-        assert!(stderr.contains("Uploading \"soroban_increment_contract\" wasm bytecode on-chain"));
-        assert!(
-            stderr.contains("Uploading \"soroban_custom_types_contract\" wasm bytecode on-chain")
-        );
+
+        // Failed contract should emit an inline error line
+        assert!(stderr.contains("Failed to generate client for: soroban_token_contract"));
 
         // Check that successful contracts are still deployed
         assert!(

--- a/crates/stellar-scaffold-cli/tests/it/features/extensions.rs
+++ b/crates/stellar-scaffold-cli/tests/it/features/extensions.rs
@@ -67,16 +67,24 @@ soroban_token_contract.client = false
 
         let stdout = String::from_utf8_lossy(&output.stdout);
 
-        // Every registered hook should have fired.
+        // pre-dev / post-dev are watch-only hooks and must NOT fire during build.
+        assert!(
+            !stdout.contains("test-ext:pre-dev"),
+            "pre-dev must not fire during build"
+        );
+        assert!(
+            !stdout.contains("test-ext:post-dev"),
+            "post-dev must not fire during build"
+        );
+
+        // Every build-phase hook should have fired.
         for hook in &[
-            "test-ext:pre-dev",
             "test-ext:pre-compile",
             "test-ext:post-compile",
             "test-ext:pre-deploy",
             "test-ext:post-deploy",
             "test-ext:pre-codegen",
             "test-ext:post-codegen",
-            "test-ext:post-dev",
         ] {
             assert!(
                 stdout.contains(hook),
@@ -91,10 +99,6 @@ soroban_token_contract.client = false
                 .unwrap_or_else(|| panic!("{marker} not found"))
         };
 
-        assert!(
-            pos("test-ext:pre-dev") < pos("test-ext:pre-compile"),
-            "pre-dev must precede pre-compile"
-        );
         assert!(
             pos("test-ext:pre-compile") < pos("test-ext:post-compile"),
             "pre-compile must precede post-compile"
@@ -114,10 +118,6 @@ soroban_token_contract.client = false
         assert!(
             pos("test-ext:pre-codegen") < pos("test-ext:post-codegen"),
             "pre-codegen must precede post-codegen"
-        );
-        assert!(
-            pos("test-ext:post-codegen") < pos("test-ext:post-dev"),
-            "post-codegen must precede post-dev"
         );
     });
 }

--- a/crates/stellar-scaffold-cli/tests/it/features/extensions.rs
+++ b/crates/stellar-scaffold-cli/tests/it/features/extensions.rs
@@ -121,3 +121,75 @@ soroban_token_contract.client = false
         );
     });
 }
+
+/// Regression test for a past CI failure where `post-codegen` was silently
+/// skipped whenever any step inside `generate_contract_bindings` errored
+/// (the `?` short-circuits returned before the hook fired). The lifecycle
+/// contract is: every fired pre-X has a matching post-X, regardless of
+/// whether the inner step succeeded.
+#[test]
+fn extension_post_codegen_fires_when_codegen_step_fails() {
+    TestEnv::from("soroban-init-boilerplate", |env| {
+        let bin_dir = env.temp_dir.path().join("ext-bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+
+        // Same test extension as above.
+        let script_path = bin_dir.join("stellar-scaffold-test-ext");
+        std::fs::write(&script_path, TEST_EXT_SCRIPT).unwrap();
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        // Shim `npm` to exit non-zero. Codegen's `npm install` / `npm run build`
+        // steps inside generate_contract_bindings will fail deterministically.
+        let npm_shim = bin_dir.join("npm");
+        std::fs::write(
+            &npm_shim,
+            "#!/bin/sh\necho 'npm shim: forcing failure' >&2\nexit 99\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&npm_shim, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let custom_path = format!("{}:{}", bin_dir.display(), TestEnv::stellar_path());
+
+        env.set_environments_toml(format!(
+            r#"
+development.accounts = [
+    {{ name = "alice" }},
+]
+development.extensions = ["test-ext"]
+
+[development.network]
+rpc-url = "{}"
+network-passphrase = "Standalone Network ; February 2017"
+
+[development.contracts]
+soroban_hello_world_contract.client = true
+soroban_increment_contract.client = false
+soroban_custom_types_contract.client = false
+soroban_auth_contract.client = false
+soroban_token_contract.client = false
+"#,
+            rpc_url()
+        ));
+
+        let output = env
+            .scaffold_build("development", false)
+            .env("PATH", &custom_path)
+            .output()
+            .expect("Failed to run scaffold build");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let combined = format!("{stdout}\n{stderr}");
+
+        // pre-codegen must fire (it runs before the rebuild block) and
+        // post-codegen must still fire even though the rebuild block errored.
+        assert!(
+            combined.contains("test-ext:pre-codegen"),
+            "pre-codegen must fire before the rebuild block.\nSTDOUT:\n{stdout}\n---\nSTDERR:\n{stderr}"
+        );
+        assert!(
+            combined.contains("test-ext:post-codegen"),
+            "post-codegen must fire even when an inner codegen step errored — this is the lifecycle contract.\nSTDOUT:\n{stdout}\n---\nSTDERR:\n{stderr}"
+        );
+    });
+}

--- a/crates/stellar-scaffold-cli/tests/it/features/extensions.rs
+++ b/crates/stellar-scaffold-cli/tests/it/features/extensions.rs
@@ -1,0 +1,123 @@
+use std::os::unix::fs::PermissionsExt;
+use stellar_scaffold_test::{TestEnv, rpc_url};
+
+/// A minimal shell-script "extension" that echoes each hook name to stdout
+/// so we can assert hook firing order and context args
+const TEST_EXT_SCRIPT: &str = r#"#!/bin/sh
+case "$1" in
+  manifest)
+    printf '{"name":"test-ext","version":"0.1.0","hooks":["pre-compile","post-compile","pre-deploy","post-deploy","pre-codegen","post-codegen","pre-dev","post-dev"]}'
+    ;;
+  pre-compile)  echo "test-ext:pre-compile"  ;;
+  post-compile) echo "test-ext:post-compile" ;;
+  pre-deploy)   echo "test-ext:pre-deploy"   ;;
+  post-deploy)  echo "test-ext:post-deploy"  ;;
+  pre-codegen)  echo "test-ext:pre-codegen"  ;;
+  post-codegen) echo "test-ext:post-codegen" ;;
+  pre-dev)      echo "test-ext:pre-dev"      ;;
+  post-dev)     echo "test-ext:post-dev"     ;;
+esac
+"#;
+
+#[test]
+fn extension_hooks_fire_in_order() {
+    TestEnv::from("soroban-init-boilerplate", |env| {
+        // Write the shell-script extension to a temp bin dir and make it executable.
+        let bin_dir = env.temp_dir.path().join("ext-bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let script_path = bin_dir.join("stellar-scaffold-test-ext");
+        std::fs::write(&script_path, TEST_EXT_SCRIPT).unwrap();
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        // Prepend our bin dir so `which stellar-scaffold-test-ext` finds it.
+        let custom_path = format!("{}:{}", bin_dir.display(), TestEnv::stellar_path());
+
+        env.set_environments_toml(format!(
+            r#"
+development.accounts = [
+    {{ name = "alice" }},
+]
+development.extensions = ["test-ext"]
+
+[development.network]
+rpc-url = "{}"
+network-passphrase = "Standalone Network ; February 2017"
+
+[development.contracts]
+soroban_hello_world_contract.client = true
+soroban_increment_contract.client = false
+soroban_custom_types_contract.client = false
+soroban_auth_contract.client = false
+soroban_token_contract.client = false
+"#,
+            rpc_url()
+        ));
+
+        let output = env
+            .scaffold_build("development", false)
+            .env("PATH", &custom_path)
+            .output()
+            .expect("Failed to run scaffold build");
+
+        assert!(
+            output.status.success(),
+            "Build failed:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        // Every registered hook should have fired.
+        for hook in &[
+            "test-ext:pre-dev",
+            "test-ext:pre-compile",
+            "test-ext:post-compile",
+            "test-ext:pre-deploy",
+            "test-ext:post-deploy",
+            "test-ext:pre-codegen",
+            "test-ext:post-codegen",
+            "test-ext:post-dev",
+        ] {
+            assert!(
+                stdout.contains(hook),
+                "expected hook output not found: {hook}"
+            );
+        }
+
+        // Verify lifecycle ordering within the output.
+        let pos = |marker: &str| {
+            stdout
+                .find(marker)
+                .unwrap_or_else(|| panic!("{marker} not found"))
+        };
+
+        assert!(
+            pos("test-ext:pre-dev") < pos("test-ext:pre-compile"),
+            "pre-dev must precede pre-compile"
+        );
+        assert!(
+            pos("test-ext:pre-compile") < pos("test-ext:post-compile"),
+            "pre-compile must precede post-compile"
+        );
+        assert!(
+            pos("test-ext:post-compile") < pos("test-ext:pre-deploy"),
+            "post-compile must precede pre-deploy"
+        );
+        assert!(
+            pos("test-ext:pre-deploy") < pos("test-ext:post-deploy"),
+            "pre-deploy must precede post-deploy"
+        );
+        assert!(
+            pos("test-ext:post-deploy") < pos("test-ext:pre-codegen"),
+            "post-deploy must precede pre-codegen"
+        );
+        assert!(
+            pos("test-ext:pre-codegen") < pos("test-ext:post-codegen"),
+            "pre-codegen must precede post-codegen"
+        );
+        assert!(
+            pos("test-ext:post-codegen") < pos("test-ext:post-dev"),
+            "post-codegen must precede post-dev"
+        );
+    });
+}

--- a/crates/stellar-scaffold-cli/tests/it/features/mod.rs
+++ b/crates/stellar-scaffold-cli/tests/it/features/mod.rs
@@ -2,4 +2,5 @@ mod clean;
 mod extensions;
 mod init_script;
 mod network;
+mod reporter;
 mod watch;

--- a/crates/stellar-scaffold-cli/tests/it/features/mod.rs
+++ b/crates/stellar-scaffold-cli/tests/it/features/mod.rs
@@ -1,4 +1,5 @@
 mod clean;
+mod extensions;
 mod init_script;
 mod network;
 mod watch;

--- a/crates/stellar-scaffold-cli/tests/it/features/mod.rs
+++ b/crates/stellar-scaffold-cli/tests/it/features/mod.rs
@@ -2,5 +2,4 @@ mod clean;
 mod extensions;
 mod init_script;
 mod network;
-mod reporter;
 mod watch;

--- a/crates/stellar-scaffold-cli/tests/it/features/reporter.rs
+++ b/crates/stellar-scaffold-cli/tests/it/features/reporter.rs
@@ -1,0 +1,175 @@
+use assert_cmd::cargo::cargo_bin;
+use stellar_scaffold_test::{TestEnv, rpc_url};
+
+/// Returns a PATH string with the reporter binary's directory prepended so
+/// `which stellar-scaffold-reporter` finds it during extension discovery.
+fn reporter_path() -> String {
+    let reporter_bin = cargo_bin("stellar-scaffold-reporter");
+    format!(
+        "{}:{}",
+        reporter_bin.parent().unwrap().display(),
+        TestEnv::stellar_path()
+    )
+}
+
+#[test]
+fn reporter_standard_output() {
+    TestEnv::from("soroban-init-boilerplate", |env| {
+        let log_path = "target/scaffold-reporter/build.log";
+
+        env.set_environments_toml(format!(
+            r#"
+development.accounts = [
+    {{ name = "alice" }},
+]
+development.extensions = ["reporter"]
+
+[development.network]
+rpc-url = "{}"
+network-passphrase = "Standalone Network ; February 2017"
+
+[development.contracts]
+soroban_hello_world_contract.client = true
+soroban_increment_contract.client = false
+soroban_custom_types_contract.client = false
+soroban_auth_contract.client = false
+soroban_token_contract.client = false
+
+[development.ext.reporter]
+mode = "standard"
+log_file = "{log_path}"
+"#,
+            rpc_url()
+        ));
+
+        let output = env
+            .scaffold_build("development", false)
+            .env("PATH", reporter_path())
+            .output()
+            .expect("Failed to run scaffold build");
+
+        assert!(
+            output.status.success(),
+            "Build failed:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        // post-compile: timing and WASM sizes table
+        assert!(stdout.contains("📋 Compile time:"), "compile time missing");
+        assert!(
+            stdout.contains("📋 WASM sizes:"),
+            "WASM sizes header missing"
+        );
+        assert!(
+            stdout.contains("soroban_hello_world_contract:"),
+            "WASM size entry missing"
+        );
+
+        // post-deploy: contract details including fresh deploy kind
+        assert!(
+            stdout.contains("📋 Deployed soroban_hello_world_contract (deployed fresh):"),
+            "deploy details missing"
+        );
+        assert!(stdout.contains("    id = "), "contract id missing");
+        assert!(stdout.contains("    hash = "), "wasm hash missing");
+
+        // post-codegen: timing and package size
+        assert!(
+            stdout.contains("📋 Codegen soroban_hello_world_contract:"),
+            "codegen details missing"
+        );
+        assert!(
+            stdout.contains("    package size ="),
+            "package size missing"
+        );
+
+        // post-dev: build cycle summary
+        assert!(
+            stdout.contains("📋 build cycle complete:"),
+            "post-dev summary missing"
+        );
+
+        // log file should exist and contain the same output
+        let log_file = env.cwd.join(log_path);
+        assert!(log_file.exists(), "log file was not created");
+        let log_content = std::fs::read_to_string(log_file).unwrap();
+        assert!(log_content.contains("📋 Compile time:"));
+        assert!(log_content.contains("📋 build cycle complete:"));
+    });
+}
+
+#[test]
+fn reporter_minimal_output() {
+    TestEnv::from("soroban-init-boilerplate", |env| {
+        env.set_environments_toml(format!(
+            r#"
+development.accounts = [
+    {{ name = "alice" }},
+]
+development.extensions = ["reporter"]
+
+[development.network]
+rpc-url = "{}"
+network-passphrase = "Standalone Network ; February 2017"
+
+[development.contracts]
+soroban_hello_world_contract.client = true
+soroban_increment_contract.client = false
+soroban_custom_types_contract.client = false
+soroban_auth_contract.client = false
+soroban_token_contract.client = false
+
+[development.ext.reporter]
+mode = "minimal"
+warn_size_kb = 0.1
+"#,
+            rpc_url()
+        ));
+
+        let output = env
+            .scaffold_build("development", false)
+            .env("PATH", reporter_path())
+            .output()
+            .expect("Failed to run scaffold build");
+
+        assert!(
+            output.status.success(),
+            "Build failed:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        // post-dev summary always fires
+        assert!(
+            stdout.contains("📋 build cycle complete:"),
+            "post-dev summary missing"
+        );
+
+        // per-contract metrics suppressed at minimal verbosity
+        assert!(
+            !stdout.contains("📋 Compile time:"),
+            "compile time should be suppressed at minimal"
+        );
+        assert!(
+            !stdout.contains("📋 WASM sizes:"),
+            "WASM sizes should be suppressed at minimal"
+        );
+        assert!(
+            !stdout.contains("📋 Deployed"),
+            "deploy details should be suppressed at minimal"
+        );
+        assert!(
+            !stdout.contains("📋 Codegen"),
+            "codegen details should be suppressed at minimal"
+        );
+
+        // warn_size_kb fires regardless of verbosity level
+        assert!(
+            stdout.contains("⚠️") && stdout.contains("exceeds threshold of"),
+            "WASM size warning should fire at any verbosity"
+        );
+    });
+}

--- a/crates/stellar-scaffold-cli/tests/it/features/reporter.rs
+++ b/crates/stellar-scaffold-cli/tests/it/features/reporter.rs
@@ -1,10 +1,9 @@
-use assert_cmd::cargo::cargo_bin;
 use stellar_scaffold_test::{TestEnv, rpc_url};
 
 /// Returns a PATH string with the reporter binary's directory prepended so
 /// `which stellar-scaffold-reporter` finds it during extension discovery.
 fn reporter_path() -> String {
-    let reporter_bin = cargo_bin("stellar-scaffold-reporter");
+    let reporter_bin = assert_cmd::cargo::cargo_bin!("stellar-scaffold-reporter");
     format!(
         "{}:{}",
         reporter_bin.parent().unwrap().display(),

--- a/crates/stellar-scaffold-ext-types/README.md
+++ b/crates/stellar-scaffold-ext-types/README.md
@@ -1,0 +1,193 @@
+# stellar-scaffold-ext-types
+
+Shared types for [Scaffold Stellar](https://scaffoldstellar.com) extension hooks.
+
+Extensions are binaries on your `PATH` named `stellar-scaffold-<name>`. Scaffold discovers them, calls `manifest` to learn which hooks they want, then invokes them at each registered lifecycle point by writing a JSON object to stdin.
+
+This crate gives Rust extension authors typed, zero-boilerplate access to that JSON. If you are writing an extension in another language you do not need this crate — just parse the raw JSON directly.
+
+---
+
+## Installation
+
+Add the crate to your extension's `Cargo.toml`:
+
+```toml
+[dependencies]
+stellar-scaffold-ext-types = "0.0.1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+```
+
+---
+
+## Types
+
+### `HookName`
+
+An exhaustive enum of every lifecycle hook Scaffold can fire, serialized as kebab-case strings:
+
+| Variant | String |
+|---|---|
+| `HookName::PreCompile` | `"pre-compile"` |
+| `HookName::PostCompile` | `"post-compile"` |
+| `HookName::PreDeploy` | `"pre-deploy"` |
+| `HookName::PostDeploy` | `"post-deploy"` |
+| `HookName::PreCodegen` | `"pre-codegen"` |
+| `HookName::PostCodegen` | `"post-codegen"` |
+| `HookName::PreDev` | `"pre-dev"` |
+| `HookName::PostDev` | `"post-dev"` |
+
+Use `HookName::as_str()` to get the string form needed in a manifest's `hooks` array.
+
+### `ExtensionManifest`
+
+The JSON your binary must write to stdout when called with the `manifest` subcommand:
+
+```rust
+ExtensionManifest {
+    name: String,    // e.g. "my-extension"
+    version: String, // SemVer, e.g. "1.0.0"
+    hooks: Vec<String>, // only the hooks you handle
+}
+```
+
+### Context structs
+
+Each hook receives one context type on stdin. The types form a strict information superset going down the build chain:
+
+```
+CompileContext  ──  pre-compile, post-compile
+    ⊂
+DeployContext   ──  pre-deploy, post-deploy
+    ⊂
+CodegenContext  ──  pre-codegen, post-codegen
+
+ProjectContext  ──  pre-dev, post-dev  (aggregates all contracts)
+```
+
+`DeployContext` composes `CompileContext` via `#[serde(flatten)]`. The wire format is a flat JSON object, but in Rust you access compile-stage fields through `ctx.compile.*`, e.g. `ctx.compile.project_root`.
+
+`CodegenContext` composes `DeployContext` the same way: compile fields are at `ctx.deploy.compile.*`.
+
+#### `config` field
+
+Every context type carries the extension's own configuration from `environments.toml`. Where it lives depends on the hook:
+
+| Hook group | Access path |
+|---|---|
+| pre/post-compile | `ctx.config` |
+| pre/post-deploy | `ctx.compile.config` |
+| pre/post-codegen | `ctx.deploy.compile.config` |
+| pre/post-dev | `ctx.config` |
+
+The field is typed `Option<serde_json::Value>`. When no config is provided it is `None` and is absent from the JSON entirely (`#[serde(skip_serializing_if = "Option::is_none")]`). Scaffold always injects the real value from `environments.toml` when config is present.
+
+---
+
+## Wire format
+
+All hooks receive a **flat** JSON object on stdin regardless of how the Rust structs compose. Fields present at each hook:
+
+| Field | pre/post-compile | pre/post-deploy | pre/post-codegen | pre/post-dev |
+|---|---|---|---|---|
+| `config` | ✓ | ✓ | ✓ | ✓ |
+| `project_root` | ✓ | ✓ | ✓ | ✓ |
+| `env` | ✓ | ✓ | ✓ | ✓ |
+| `wasm_out_dir` | ✓ | ✓ | ✓ | ✓ |
+| `source_dirs` | ✓ | ✓ | ✓ | ✓ |
+| `wasm_paths` | ✓ (empty at pre) | ✓ | ✓ | — |
+| `network` | — | ✓ | ✓ | ✓ (if `--build-clients`) |
+| `contract_name` | — | ✓ | ✓ | — |
+| `wasm_path` | — | ✓ | ✓ | — |
+| `wasm_hash` | — | ✓ | ✓ | — |
+| `contract_id` | — | ✓ (`null` at pre) | ✓ | — |
+| `ts_package_dir` | — | — | ✓ | — |
+| `src_template_path` | — | — | ✓ | — |
+| `contracts` | — | — | — | ✓ |
+| `watch_paths` | — | — | — | ✓ |
+
+### `network` object
+
+```json
+{
+  "rpc_url": "http://localhost:8000/soroban/rpc",
+  "network_passphrase": "Standalone Network ; February 2017",
+  "network_name": "local"
+}
+```
+
+`network_name` is `null` when the network was configured with explicit `rpc_url`/`network_passphrase` rather than a named preset.
+
+### `wasm_paths` object
+
+```json
+{
+  "hello_world": "/path/to/project/target/stellar/local/hello_world.wasm",
+  "another_contract": "/path/to/project/target/stellar/local/another_contract.wasm"
+}
+```
+
+Empty object `{}` at `pre-compile`.
+
+### `contracts` array (pre-dev / post-dev only)
+
+Array of per-contract objects. All optional fields are `null` at `pre-dev` and populated at `post-dev` for contracts that were successfully processed:
+
+```json
+[
+  {
+    "name": "hello_world",
+    "source_dir": "/path/to/project/contracts/hello_world",
+    "wasm_path": "/path/to/project/target/stellar/local/hello_world.wasm",
+    "wasm_hash": "abc123...",
+    "contract_id": "CAAAAAAA...",
+    "ts_package_dir": "/path/to/project/packages/hello_world",
+    "src_template_path": "/path/to/project/src/contracts/hello_world.ts"
+  }
+]
+```
+
+---
+
+## Minimal example
+
+```rust
+use std::io::Read;
+use stellar_scaffold_ext_types::{ExtensionManifest, HookName, CompileContext};
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    match args.get(1).map(String::as_str) {
+        Some("manifest") => {
+            let manifest = ExtensionManifest {
+                name: "my-extension".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                hooks: vec![HookName::PostCompile.as_str().to_string()],
+            };
+            println!("{}", serde_json::to_string(&manifest).unwrap());
+        }
+        Some("post-compile") => {
+            let mut buf = String::new();
+            std::io::stdin().read_to_string(&mut buf).unwrap();
+            let ctx: CompileContext = serde_json::from_str(&buf).unwrap();
+
+            println!("Build finished. WASM files:");
+            for (name, path) in &ctx.wasm_paths {
+                println!("  {name}: {}", path.display());
+            }
+        }
+        _ => {}
+    }
+}
+```
+
+For a complete, production-quality example see the [`stellar-scaffold-reporter`](../stellar-scaffold-reporter) crate. It is the built-in Scaffold extension that tracks compile times, WASM sizes, deploy info, and total build cycle duration.
+
+---
+
+## Non-Rust extensions
+
+Extensions are ordinary binaries. You can write them in any language. The JSON Scaffold sends on stdin is a plain flat object — just read stdin and parse it with your language's JSON library. You do not need this crate.
+
+See the [Scaffold Extensions documentation](https://scaffoldstellar.com/docs/extensions) for language-agnostic examples and the full field reference.

--- a/crates/stellar-scaffold-ext-types/src/lib.rs
+++ b/crates/stellar-scaffold-ext-types/src/lib.rs
@@ -120,18 +120,6 @@ pub struct ExtensionManifest {
 }
 
 // ---------------------------------------------------------------------------
-// ExtensionConfig
-// ---------------------------------------------------------------------------
-
-/// Arbitrary per-extension configuration, sourced from `environments.toml`.
-///
-/// The scaffold tool passes this opaque value to extensions alongside the hook
-/// context. Extensions are responsible for deserializing it into their own
-/// config struct.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExtensionConfig(pub serde_json::Value);
-
-// ---------------------------------------------------------------------------
 // NetworkConfig
 // ---------------------------------------------------------------------------
 
@@ -172,6 +160,11 @@ pub struct NetworkConfig {
 /// | `wasm_paths` | empty | populated |
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CompileContext {
+    /// Per-extension config from `[env.ext.<name>]` in `environments.toml`.
+    /// `None` when no config was provided for this extension.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<serde_json::Value>,
+
     /// Absolute path to the Cargo workspace root (where `Cargo.toml` and
     /// `environments.toml` live).
     pub project_root: PathBuf,
@@ -345,6 +338,11 @@ pub struct ProjectContractInfo {
 /// | `contracts[*].wasm_path` etc. | `None` | populated |
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProjectContext {
+    /// Per-extension config from `[env.ext.<name>]` in `environments.toml`.
+    /// `None` when no config was provided for this extension.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<serde_json::Value>,
+
     /// Absolute path to the Cargo workspace root.
     pub project_root: PathBuf,
 

--- a/crates/stellar-scaffold-ext-types/src/lib.rs
+++ b/crates/stellar-scaffold-ext-types/src/lib.rs
@@ -199,17 +199,20 @@ pub struct CompileContext {
 // DeployContext  (pre-deploy / post-deploy)
 // ---------------------------------------------------------------------------
 
-/// Whether a contract was freshly instantiated or upgraded in-place.
+/// Whether a contract was freshly instantiated, upgraded in-place, or already current.
 ///
 /// Available at `post-deploy` via [`DeployContext::deploy_kind`].
 /// Always `None` at `pre-deploy` (the action has not yet occurred).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DeployKind {
-    /// The contract was instantiated for the first time.
+    /// The contract was instantiated for the first time (new contract ID).
     Fresh,
     /// The contract already existed; its WASM was upgraded via the `upgrade` function.
+    /// The contract ID is unchanged.
     Upgraded,
+    /// The contract already existed with the same WASM hash; no on-chain action was taken.
+    Unchanged,
 }
 
 /// Context passed to `pre-deploy` and `post-deploy` hooks.

--- a/crates/stellar-scaffold-ext-types/src/lib.rs
+++ b/crates/stellar-scaffold-ext-types/src/lib.rs
@@ -199,6 +199,19 @@ pub struct CompileContext {
 // DeployContext  (pre-deploy / post-deploy)
 // ---------------------------------------------------------------------------
 
+/// Whether a contract was freshly instantiated or upgraded in-place.
+///
+/// Available at `post-deploy` via [`DeployContext::deploy_kind`].
+/// Always `None` at `pre-deploy` (the action has not yet occurred).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeployKind {
+    /// The contract was instantiated for the first time.
+    Fresh,
+    /// The contract already existed; its WASM was upgraded via the `upgrade` function.
+    Upgraded,
+}
+
 /// Context passed to `pre-deploy` and `post-deploy` hooks.
 ///
 /// Fired once per contract. Includes all fields from [`CompileContext`] (via
@@ -214,6 +227,7 @@ pub struct CompileContext {
 /// | `wasm_path` | ✓ | ✓ |
 /// | `wasm_hash` | ✓ | ✓ |
 /// | `contract_id` | `None` | `Some(…)` |
+/// | `deploy_kind` | `None` | `Some(…)` |
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeployContext {
     /// All compile-stage fields (project root, env, wasm paths, etc.).
@@ -242,6 +256,12 @@ pub struct DeployContext {
     /// confirmed to exist at this hash). `Some` at `post-deploy`, regardless
     /// of whether the contract was freshly deployed or upgraded in-place.
     pub contract_id: Option<String>,
+
+    /// Whether the contract was freshly instantiated or upgraded in-place.
+    ///
+    /// `None` at `pre-deploy` (the action has not yet occurred).
+    /// `Some` at `post-deploy`.
+    pub deploy_kind: Option<DeployKind>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/stellar-scaffold-ext-types/src/lib.rs
+++ b/crates/stellar-scaffold-ext-types/src/lib.rs
@@ -46,6 +46,7 @@ use serde::{Deserialize, Serialize};
 /// etc.). Use [`HookName::as_str`] to compare against manifest entries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum HookName {
     /// Fired once before `cargo build` runs for any contract.
     PreCompile,
@@ -205,6 +206,7 @@ pub struct CompileContext {
 /// Always `None` at `pre-deploy` (the action has not yet occurred).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum DeployKind {
     /// The contract was instantiated for the first time (new contract ID).
     Fresh,

--- a/crates/stellar-scaffold-reporter/Cargo.toml
+++ b/crates/stellar-scaffold-reporter/Cargo.toml
@@ -19,3 +19,13 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 clap = { version = "4", features = ["derive"] }
 thiserror = "2"
+
+[dev-dependencies]
+assert_cmd = "2.1.1"
+stellar-scaffold-test = { path = "../stellar-scaffold-test" }
+
+[features]
+integration-tests = []
+
+[lints]
+workspace = true

--- a/crates/stellar-scaffold-reporter/Cargo.toml
+++ b/crates/stellar-scaffold-reporter/Cargo.toml
@@ -18,7 +18,6 @@ stellar-scaffold-ext-types = { path = "../stellar-scaffold-ext-types" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 clap = { version = "4", features = ["derive"] }
-thiserror = "2"
 
 [dev-dependencies]
 assert_cmd = "2.1.1"

--- a/crates/stellar-scaffold-reporter/Cargo.toml
+++ b/crates/stellar-scaffold-reporter/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "stellar-scaffold-reporter"
+description = "Scaffold Stellar plugin for logging development metrics"
+homepage = "https://github.com/theahaco/scaffold-stellar"
+authors = ["Aha Labs <hello@theaha.co>"]
+license = "Apache-2.0"
+readme = "README.md"
+version = "0.1.0"
+edition = "2024"
+repository = "https://github.com/theahaco/scaffold-stellar/tree/main/crates/stellar-scaffold-reporter"
+
+[[bin]]
+name = "stellar-scaffold-reporter"
+path = "src/main.rs"
+
+[dependencies]
+stellar-scaffold-ext-types = { path = "../stellar-scaffold-ext-types" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+clap = { version = "4", features = ["derive"] }
+thiserror = "2"

--- a/crates/stellar-scaffold-reporter/README.md
+++ b/crates/stellar-scaffold-reporter/README.md
@@ -1,0 +1,37 @@
+# Scaffold Reporter
+
+An extension for [Scaffold Stellar](https://scaffoldstellar.org) to measure and log useful metrics for contract and dApp developers.
+
+## 📐 What Metrics?
+
+- **WASM size:** When you deploy a Stellar smart contract, you're uploading a compiled binary (the `.wasm` file) to a shared global ledger. _Every byte you store costs fees, and there's a hard cap of ~128KB._ As your contract grows, you'll start paying unexpectedly more or even hit the cap. Treat it like bundle size in a web app.
+- **WASM hash:** Think of this as a git commit hash for your compiled binary. _Two identical compilations produce the same hash and the network uses this to deduplicate._ If that hash is already uploaded, it skips the upload and just creates a new instance pointing to the existing code.
+- **Deploy vs. Upgrade:** Fresh deploys create a brand-new contract with a new address. Upgrades swap the code at the existing address _while preserving all its stored data._ Think of this like a schema migration for an existing database. The environment matters. Fresh deploys during development are fine, but accidental deploys in production mean your frontend is pointing at a dead address.
+- **Compile duration:** Stellar contracts compile to WebAssembly. _Rust → WASM compilation can be slow._ Tracking it over time catches CI regressions.
+- **TypeScript package size:** Scaffold generates a TypeScript client bundled with your frontend. _A large bundle has a real cost to users downloading your dApp._
+- **Total build time:** This is the end-to-end latency of `stellar scaffold watch`, from "I saved a file" to "my frontend client is regenerated." _This is your core development feedback loop._
+
+## 📦 Installation
+
+If you started your project with `stellar scaffold init`, congrats! You already have it!
+
+Otherwise, install the crate with [Cargo]():
+
+``` sh
+cargo install stellar-scaffold-reporter
+```
+
+And register it in your Scaffold `environments.toml` file:
+
+``` toml
+[development]
+extensions = [reporter]
+```
+
+## 🏃 Running the Reporter
+
+That's all you need! Any time you run a `stellar scaffold build` or `stellar scaffold watch` command, you'll see the reports logged to the console. You can also view reports in the `.scaffold/reports/` directory.
+
+## ⚙️ Configuration
+
+TODO

--- a/crates/stellar-scaffold-reporter/README.md
+++ b/crates/stellar-scaffold-reporter/README.md
@@ -1,37 +1,40 @@
 # Scaffold Reporter
 
-An extension for [Scaffold Stellar](https://scaffoldstellar.org) to measure and log useful metrics for contract and dApp developers.
+An extension for [Scaffold Stellar](https://scaffoldstellar.org) that logs useful build metrics to your console during every compile, deploy, and watch cycle.
 
-## 📐 What Metrics?
+## 📐 What Gets Reported?
 
-- **WASM size:** When you deploy a Stellar smart contract, you're uploading a compiled binary (the `.wasm` file) to a shared global ledger. _Every byte you store costs fees, and there's a hard cap of ~128KB._ As your contract grows, you'll start paying unexpectedly more or even hit the cap. Treat it like bundle size in a web app.
-- **WASM hash:** Think of this as a git commit hash for your compiled binary. _Two identical compilations produce the same hash and the network uses this to deduplicate._ If that hash is already uploaded, it skips the upload and just creates a new instance pointing to the existing code.
-- **Deploy vs. Upgrade:** Fresh deploys create a brand-new contract with a new address. Upgrades swap the code at the existing address _while preserving all its stored data._ Think of this like a schema migration for an existing database. The environment matters. Fresh deploys during development are fine, but accidental deploys in production mean your frontend is pointing at a dead address.
-- **Compile duration:** Stellar contracts compile to WebAssembly. _Rust → WASM compilation can be slow._ Tracking it over time catches CI regressions.
-- **TypeScript package size:** Scaffold generates a TypeScript client bundled with your frontend. _A large bundle has a real cost to users downloading your dApp._
-- **Total build time:** This is the end-to-end latency of `stellar scaffold watch`, from "I saved a file" to "my frontend client is regenerated." _This is your core development feedback loop._
+- **Compile time:** How long `cargo build` took for all contracts in the workspace.
+- **WASM size:** Size in KB for each compiled contract, with a delta from the previous build (e.g. `▲ 240B` or `▼ 80B`). Every byte matters. Storage on Stellar costs fees, and there is a hard cap near 128KB.
+- **WASM hash:** The SHA-256 of the uploaded bytecode. Two identical compilations produce the same hash; the network deduplicates uploads automatically.
+- **Deploy vs. upgrade:** Fresh deploys create a new contract address. Upgrades swap the code at the existing address while preserving all stored data. The reporter tells you which one happened.
+- **Deploy duration:** How long the upload + deploy/upgrade step took, per contract.
+- **TypeScript package size:** Size of the generated client package bundled with your frontend.
+- **Total build time:** End-to-end latency from file save to regenerated frontend client. Your core development feedback loop!
 
 ## 📦 Installation
 
-If you started your project with `stellar scaffold init`, congrats! You already have it!
+If you started your project with `stellar scaffold init`, the reporter is already included.
 
-Otherwise, install the crate with [Cargo]():
+To add it to an existing project, install the binary with [Cargo](https://doc.rust-lang.org/cargo/commands/cargo-install.html):
 
-``` sh
+```sh
 cargo install stellar-scaffold-reporter
 ```
 
-And register it in your Scaffold `environments.toml` file:
+Then register it in your `environments.toml`:
 
-``` toml
+```toml
 [development]
-extensions = [reporter]
+extensions = ["reporter"]
 ```
 
-## 🏃 Running the Reporter
+## 🏃 Running
 
-That's all you need! Any time you run a `stellar scaffold build` or `stellar scaffold watch` command, you'll see the reports logged to the console. You can also view reports in the `.scaffold/reports/` directory.
+That's it. The reporter runs automatically whenever you use `stellar scaffold build` or `stellar scaffold watch`. Output is written to your console alongside Scaffold's own output.
 
 ## ⚙️ Configuration
 
-TODO
+No configuration is required. The reporter works out of the box with sensible defaults.
+
+More configuration options will be documented here as they are introduced.

--- a/crates/stellar-scaffold-reporter/src/lib.rs
+++ b/crates/stellar-scaffold-reporter/src/lib.rs
@@ -1,0 +1,2 @@
+// Empty lib target required so this crate can be added as a dev-dependency,
+// which causes Cargo to set CARGO_BIN_EXE_stellar-scaffold-reporter for tests.

--- a/crates/stellar-scaffold-reporter/src/main.rs
+++ b/crates/stellar-scaffold-reporter/src/main.rs
@@ -241,6 +241,7 @@ fn cmd_post_deploy() {
         let contract_id = ctx.contract_id.as_deref().unwrap_or("(unknown)");
         let kind = match ctx.deploy_kind {
             Some(DeployKind::Upgraded) => "upgraded in-place",
+            Some(DeployKind::Unchanged) => "unchanged",
             Some(DeployKind::Fresh) | None => "deployed fresh",
         };
 

--- a/crates/stellar-scaffold-reporter/src/main.rs
+++ b/crates/stellar-scaffold-reporter/src/main.rs
@@ -11,18 +11,18 @@
 //!
 //! ```toml
 //! [development.ext.reporter]
-//! verbosity = "standard"   # "minimal" | "standard" (default)
+//! mode = "standard"        # "standard" (default) | "minimal"
 //! warn_size_kb = 128       # warn if any WASM exceeds this size in KB
 //! log_file = "target/scaffold-reporter/build.log"  # optional log file
 //! ```
 //!
-//! ## Verbosity levels
+//! ## Modes
 //!
 //! - `standard` (default): compile timing + WASM sizes, deploy details,
 //!   codegen duration, and a post-dev build summary.
 //! - `minimal`: post-dev build summary only, plus any WASM size warnings.
 //!
-//! WASM size warnings (`warn_size_kb`) are emitted regardless of verbosity.
+//! WASM size warnings (`warn_size_kb`) are emitted regardless of mode.
 
 use crate::report::Reporter;
 use clap::{Parser, Subcommand};
@@ -40,14 +40,14 @@ pub mod state;
 #[derive(Debug, Default, serde::Deserialize)]
 struct Config {
     #[serde(default)]
-    verbosity: Verbosity,
+    mode: Mode,
     warn_size_kb: Option<f64>,
     log_file: Option<String>,
 }
 
 #[derive(Debug, Default, serde::Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
-enum Verbosity {
+enum Mode {
     /// Only emit the post-dev build summary and WASM size warnings.
     Minimal,
     /// Emit per-contract metrics: compile timing + WASM sizes, deploy details,
@@ -150,7 +150,7 @@ fn cmd_post_compile() {
     let mut state = state::load(&ctx.project_root);
     let mut reporter = Reporter::new(log_path(&ctx.project_root, &config).as_deref());
 
-    if config.verbosity == Verbosity::Standard {
+    if config.mode == Mode::Standard {
         // Compile duration
         if let Some(start) = state.compile_start {
             let elapsed = state::elapsed_since(start);
@@ -232,7 +232,7 @@ fn cmd_post_deploy() {
     let mut state = state::load(&ctx.compile.project_root);
     let mut reporter = Reporter::new(log_path(&ctx.compile.project_root, &config).as_deref());
 
-    if config.verbosity == Verbosity::Standard {
+    if config.mode == Mode::Standard {
         let elapsed = state.deploy_start.remove(&ctx.contract_name).map_or_else(
             || "?".to_string(),
             |start| format!("{:.2}s", state::elapsed_since(start)),
@@ -272,7 +272,7 @@ fn cmd_post_codegen() {
     let mut reporter =
         Reporter::new(log_path(&ctx.deploy.compile.project_root, &config).as_deref());
 
-    if config.verbosity == Verbosity::Standard {
+    if config.mode == Mode::Standard {
         let elapsed = state
             .codegen_start
             .remove(&ctx.deploy.contract_name)

--- a/crates/stellar-scaffold-reporter/src/main.rs
+++ b/crates/stellar-scaffold-reporter/src/main.rs
@@ -1,0 +1,132 @@
+use clap::{Parser, Subcommand};
+use stellar_scaffold_ext_types::{CompileContext, ExtensionManifest, HookName};
+pub mod report;
+pub mod state;
+
+#[derive(Parser)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    Manifest,
+    PreCompile,
+    PostCompile,
+    // PreDeploy,
+    // PostDeploy,
+    // PreCodegen,
+    // PostCodegen,
+    // PreDev,
+    // PostDev,
+}
+
+fn log_path(_project_root: &std::path::Path) -> Option<std::path::PathBuf> {
+    // TODO load config and join log file path to project root
+    None
+}
+
+fn main() {
+    let cli = Cli::parse();
+    match cli.command {
+        Command::Manifest => cmd_manifest(),
+        Command::PreCompile => cmd_pre_compile(),
+        Command::PostCompile => cmd_post_compile(),
+        // Command::PreDeploy => cmd_pre_deploy(),
+        // Command::PostDeploy => cmd_post_deploy(),
+        // Command::PreCodegen => cmd_pre_codegen(),
+        // Command::PostCodegen => cmd_post_codegen(),
+        // Command::PreDev => cmd_pre_dev(),
+        // Command::PostDev => cmd_post_dev(),
+    }
+}
+
+fn cmd_manifest() {
+    let manifest = ExtensionManifest {
+        name: String::from("reporter"),
+        version: String::from(env!("CARGO_PKG_VERSION")),
+        hooks: [
+            HookName::PreCompile,
+            HookName::PostCompile,
+            // HookName::PreDeploy,
+            // HookName::PostDeploy,
+            // HookName::PreCodegen,
+            // HookName::PostCodegen,
+            // HookName::PreDev,
+            // HookName::PostDev,
+        ]
+        .map(|h| h.as_str().to_string())
+        .to_vec(),
+    };
+    println!("{}", serde_json::json!(manifest));
+}
+
+fn read_stdin<T: serde::de::DeserializeOwned>() -> T {
+    use std::io::Read;
+    let mut buf = String::new();
+    std::io::stdin()
+        .read_to_string(&mut buf)
+        .expect("failed to read stdin");
+    serde_json::from_str(&buf).expect("failed to parse context JSON from stdin")
+}
+
+fn cmd_pre_compile() {
+    let ctx: CompileContext = read_stdin();
+    let mut state = state::load(&ctx.project_root);
+    state.compile_start = Some(state::now());
+    state::save(&ctx.project_root, &state);
+}
+
+fn cmd_post_compile() {
+    let ctx: CompileContext = read_stdin();
+    let mut state = state::load(&ctx.project_root);
+    let mut reporter = report::Reporter::new(log_path(&ctx.project_root).as_deref());
+
+    // Compile duration
+    if let Some(start) = state.compile_start {
+        let elapsed = state::elapsed_since(start);
+        reporter.log(&format!("📋 Compile time: {elapsed:.2}s"));
+    }
+
+    // WASM size
+    reporter.log("📋 WASM sizes:");
+    for (name, path) in &ctx.wasm_paths {
+        let result = match std::fs::metadata(path) {
+            Ok(meta) => {
+                let size = meta.len();
+                // WASM files will be small enough for precision loss to not matter
+                #[allow(clippy::cast_precision_loss)]
+                let size_kb = size as f64 / 1024.0;
+                let delta = state
+                    .prev_wasm_sizes
+                    .get(name)
+                    .map(|&prev| {
+                        let diff = i128::from(size) - i128::from(prev);
+                        match diff.cmp(&0) {
+                            std::cmp::Ordering::Greater => format!(" (▲{diff}B)"),
+                            std::cmp::Ordering::Less => format!(" (▼{}B)", diff.unsigned_abs()),
+                            std::cmp::Ordering::Equal => " (no change)".to_string(),
+                        }
+                    })
+                    .unwrap_or_default();
+                format!("{name}: {size_kb:.1}KB{delta}")
+            }
+            Err(_) => String::from("(⚠️ WASM not found)"),
+        };
+        reporter.log(&format!("    • {name}: {result}"));
+    }
+
+    // Update state for next build
+    state.prev_wasm_sizes = ctx
+        .wasm_paths
+        .iter()
+        .filter_map(|(name, path)| {
+            std::fs::metadata(path)
+                .ok()
+                .map(|m| (name.clone(), m.len()))
+        })
+        .collect();
+    state.compile_start = None;
+    state::save(&ctx.project_root, &state);
+}

--- a/crates/stellar-scaffold-reporter/src/main.rs
+++ b/crates/stellar-scaffold-reporter/src/main.rs
@@ -1,5 +1,8 @@
+use crate::report::Reporter;
 use clap::{Parser, Subcommand};
-use stellar_scaffold_ext_types::{CompileContext, ExtensionManifest, HookName};
+use stellar_scaffold_ext_types::{
+    CodegenContext, CompileContext, DeployContext, ExtensionManifest, HookName, ProjectContext,
+};
 pub mod report;
 pub mod state;
 
@@ -14,12 +17,12 @@ enum Command {
     Manifest,
     PreCompile,
     PostCompile,
-    // PreDeploy,
-    // PostDeploy,
-    // PreCodegen,
-    // PostCodegen,
-    // PreDev,
-    // PostDev,
+    PreDeploy,
+    PostDeploy,
+    PreCodegen,
+    PostCodegen,
+    PreDev,
+    PostDev,
 }
 
 fn log_path(_project_root: &std::path::Path) -> Option<std::path::PathBuf> {
@@ -33,12 +36,12 @@ fn main() {
         Command::Manifest => cmd_manifest(),
         Command::PreCompile => cmd_pre_compile(),
         Command::PostCompile => cmd_post_compile(),
-        // Command::PreDeploy => cmd_pre_deploy(),
-        // Command::PostDeploy => cmd_post_deploy(),
-        // Command::PreCodegen => cmd_pre_codegen(),
-        // Command::PostCodegen => cmd_post_codegen(),
-        // Command::PreDev => cmd_pre_dev(),
-        // Command::PostDev => cmd_post_dev(),
+        Command::PreDeploy => cmd_pre_deploy(),
+        Command::PostDeploy => cmd_post_deploy(),
+        Command::PreCodegen => cmd_pre_codegen(),
+        Command::PostCodegen => cmd_post_codegen(),
+        Command::PreDev => cmd_pre_dev(),
+        Command::PostDev => cmd_post_dev(),
     }
 }
 
@@ -49,12 +52,12 @@ fn cmd_manifest() {
         hooks: [
             HookName::PreCompile,
             HookName::PostCompile,
-            // HookName::PreDeploy,
-            // HookName::PostDeploy,
-            // HookName::PreCodegen,
-            // HookName::PostCodegen,
-            // HookName::PreDev,
-            // HookName::PostDev,
+            HookName::PreDeploy,
+            HookName::PostDeploy,
+            HookName::PreCodegen,
+            HookName::PostCodegen,
+            HookName::PreDev,
+            HookName::PostDev,
         ]
         .map(|h| h.as_str().to_string())
         .to_vec(),
@@ -81,7 +84,7 @@ fn cmd_pre_compile() {
 fn cmd_post_compile() {
     let ctx: CompileContext = read_stdin();
     let mut state = state::load(&ctx.project_root);
-    let mut reporter = report::Reporter::new(log_path(&ctx.project_root).as_deref());
+    let mut reporter = Reporter::new(log_path(&ctx.project_root).as_deref());
 
     // Compile duration
     if let Some(start) = state.compile_start {
@@ -128,5 +131,117 @@ fn cmd_post_compile() {
         })
         .collect();
     state.compile_start = None;
+    state::save(&ctx.project_root, &state);
+}
+
+fn cmd_pre_deploy() {
+    let ctx: DeployContext = read_stdin();
+    let mut reporter = Reporter::new(log_path(&ctx.compile.project_root).as_deref());
+    reporter.log("📋 pre deploy hook");
+    let mut state = state::load(&ctx.compile.project_root);
+    state
+        .deploy_start
+        .insert(ctx.contract_name.clone(), state::now());
+    state::save(&ctx.compile.project_root, &state);
+}
+
+fn cmd_post_deploy() {
+    let ctx: DeployContext = read_stdin();
+    let mut state = state::load(&ctx.compile.project_root);
+    let mut reporter = Reporter::new(log_path(&ctx.compile.project_root).as_deref());
+    reporter.log("📋 post deploy hook");
+
+    let elapsed = state.deploy_start.remove(&ctx.contract_name).map_or_else(
+        || "?".to_string(),
+        |start| format!("{:.2}s", state::elapsed_since(start)),
+    );
+
+    let contract_id = ctx.contract_id.as_deref().unwrap_or("(unknown)");
+
+    reporter.log(&format!(
+        "📋 Deployed {}:\n    id = {}\n    hash = {}\n    duration = {}",
+        ctx.contract_name, &contract_id, &ctx.wasm_hash, elapsed,
+    ));
+
+    state::save(&ctx.compile.project_root, &state);
+}
+
+fn cmd_pre_codegen() {
+    let ctx: CodegenContext = read_stdin();
+    let mut reporter = Reporter::new(log_path(&ctx.deploy.compile.project_root).as_deref());
+    reporter.log("📋 pre codegen hook");
+    let mut state = state::load(&ctx.deploy.compile.project_root);
+    state
+        .codegen_start
+        .insert(ctx.deploy.contract_name, state::now());
+    state::save(&ctx.deploy.compile.project_root, &state);
+}
+
+fn cmd_post_codegen() {
+    let ctx: CodegenContext = read_stdin();
+    let mut state = state::load(&ctx.deploy.compile.project_root);
+    let mut reporter = Reporter::new(log_path(&ctx.deploy.compile.project_root).as_deref());
+    reporter.log("📋 post codegen hook");
+
+    let elapsed = state
+        .codegen_start
+        .remove(&ctx.deploy.contract_name)
+        .map_or_else(
+            || "?".to_string(),
+            |start| format!("{:.2}s", state::elapsed_since(start)),
+        );
+
+    // Sum the sizes of all files in ts_package_dir recursively
+    let ts_size_kb = dir_size_kb(&ctx.ts_package_dir);
+
+    reporter.log(&format!(
+        "📋 Codegen {}:\n    duration = {}\n    package size = {}",
+        ctx.deploy.contract_name, elapsed, ts_size_kb,
+    ));
+
+    state::save(&ctx.deploy.compile.project_root, &state);
+}
+
+/// Returns total size of all files under `dir` recursively, in KB.
+#[allow(clippy::cast_precision_loss)]
+fn dir_size_kb(dir: &std::path::Path) -> f64 {
+    fn visit(dir: &std::path::Path, total: &mut u64) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                visit(&path, total);
+            } else if let Ok(meta) = path.metadata() {
+                *total += meta.len();
+            }
+        }
+    }
+    let mut total = 0u64;
+    visit(dir, &mut total);
+    total as f64 / 1024.0
+}
+
+fn cmd_pre_dev() {
+    let ctx: ProjectContext = read_stdin();
+    let mut state = state::load(&ctx.project_root);
+    state.dev_start = Some(state::now());
+    state::save(&ctx.project_root, &state);
+}
+
+fn cmd_post_dev() {
+    let ctx: ProjectContext = read_stdin();
+    let mut state = state::load(&ctx.project_root);
+    let mut reporter = Reporter::new(log_path(&ctx.project_root).as_deref());
+
+    if let Some(start) = state.dev_start.take() {
+        let elapsed = state::elapsed_since(start);
+        let contract_count = ctx.contracts.len();
+        reporter.log(&format!(
+            "📋 build cycle complete: {contract_count} contract(s) in {elapsed:.2}s"
+        ));
+    }
+
     state::save(&ctx.project_root, &state);
 }

--- a/crates/stellar-scaffold-reporter/src/main.rs
+++ b/crates/stellar-scaffold-reporter/src/main.rs
@@ -75,14 +75,14 @@ fn read_stdin<T: serde::de::DeserializeOwned>() -> T {
 }
 
 fn cmd_pre_compile() {
-    let ctx: CompileContext = read_stdin();
+    let ctx = read_stdin::<CompileContext>();
     let mut state = state::load(&ctx.project_root);
     state.compile_start = Some(state::now());
     state::save(&ctx.project_root, &state);
 }
 
 fn cmd_post_compile() {
-    let ctx: CompileContext = read_stdin();
+    let ctx = read_stdin::<CompileContext>();
     let mut state = state::load(&ctx.project_root);
     let mut reporter = Reporter::new(log_path(&ctx.project_root).as_deref());
 
@@ -135,7 +135,7 @@ fn cmd_post_compile() {
 }
 
 fn cmd_pre_deploy() {
-    let ctx: DeployContext = read_stdin();
+    let ctx = read_stdin::<DeployContext>();
     let mut reporter = Reporter::new(log_path(&ctx.compile.project_root).as_deref());
     reporter.log("📋 pre deploy hook");
     let mut state = state::load(&ctx.compile.project_root);
@@ -146,7 +146,7 @@ fn cmd_pre_deploy() {
 }
 
 fn cmd_post_deploy() {
-    let ctx: DeployContext = read_stdin();
+    let ctx = read_stdin::<DeployContext>();
     let mut state = state::load(&ctx.compile.project_root);
     let mut reporter = Reporter::new(log_path(&ctx.compile.project_root).as_deref());
     reporter.log("📋 post deploy hook");
@@ -167,7 +167,7 @@ fn cmd_post_deploy() {
 }
 
 fn cmd_pre_codegen() {
-    let ctx: CodegenContext = read_stdin();
+    let ctx = read_stdin::<CodegenContext>();
     let mut reporter = Reporter::new(log_path(&ctx.deploy.compile.project_root).as_deref());
     reporter.log("📋 pre codegen hook");
     let mut state = state::load(&ctx.deploy.compile.project_root);
@@ -178,7 +178,7 @@ fn cmd_pre_codegen() {
 }
 
 fn cmd_post_codegen() {
-    let ctx: CodegenContext = read_stdin();
+    let ctx = read_stdin::<CodegenContext>();
     let mut state = state::load(&ctx.deploy.compile.project_root);
     let mut reporter = Reporter::new(log_path(&ctx.deploy.compile.project_root).as_deref());
     reporter.log("📋 post codegen hook");
@@ -224,14 +224,14 @@ fn dir_size_kb(dir: &std::path::Path) -> f64 {
 }
 
 fn cmd_pre_dev() {
-    let ctx: ProjectContext = read_stdin();
+    let ctx = read_stdin::<ProjectContext>();
     let mut state = state::load(&ctx.project_root);
     state.dev_start = Some(state::now());
     state::save(&ctx.project_root, &state);
 }
 
 fn cmd_post_dev() {
-    let ctx: ProjectContext = read_stdin();
+    let ctx = read_stdin::<ProjectContext>();
     let mut state = state::load(&ctx.project_root);
     let mut reporter = Reporter::new(log_path(&ctx.project_root).as_deref());
 

--- a/crates/stellar-scaffold-reporter/src/main.rs
+++ b/crates/stellar-scaffold-reporter/src/main.rs
@@ -1,10 +1,74 @@
+//! Stellar Scaffold Reporter extension.
+//!
+//! Reports build metrics after each phase of the scaffold lifecycle. Install
+//! this extension and add it to your `environments.toml` to see timing,
+//! WASM sizes, deployment details, and build-cycle summaries without cluttering
+//! the main scaffold output.
+//!
+//! # Configuration
+//!
+//! Configure via `[<env>.ext.reporter]` in `environments.toml`:
+//!
+//! ```toml
+//! [development.ext.reporter]
+//! verbosity = "standard"   # "minimal" | "standard" (default)
+//! warn_size_kb = 128       # warn if any WASM exceeds this size in KB
+//! log_file = "target/scaffold-reporter/build.log"  # optional log file
+//! ```
+//!
+//! ## Verbosity levels
+//!
+//! - `standard` (default): compile timing + WASM sizes, deploy details,
+//!   codegen duration, and a post-dev build summary.
+//! - `minimal`: post-dev build summary only, plus any WASM size warnings.
+//!
+//! WASM size warnings (`warn_size_kb`) are emitted regardless of verbosity.
+
 use crate::report::Reporter;
 use clap::{Parser, Subcommand};
 use stellar_scaffold_ext_types::{
-    CodegenContext, CompileContext, DeployContext, ExtensionManifest, HookName, ProjectContext,
+    CodegenContext, CompileContext, DeployContext, DeployKind, ExtensionManifest, HookName,
+    ProjectContext,
 };
 pub mod report;
 pub mod state;
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default, serde::Deserialize)]
+struct Config {
+    #[serde(default)]
+    verbosity: Verbosity,
+    warn_size_kb: Option<f64>,
+    log_file: Option<String>,
+}
+
+#[derive(Debug, Default, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+enum Verbosity {
+    /// Only emit the post-dev build summary and WASM size warnings.
+    Minimal,
+    /// Emit per-contract metrics: compile timing + WASM sizes, deploy details,
+    /// and codegen duration, plus the post-dev summary.
+    #[default]
+    Standard,
+}
+
+fn parse_config(config: Option<&serde_json::Value>) -> Config {
+    config
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default()
+}
+
+fn log_path(project_root: &std::path::Path, config: &Config) -> Option<std::path::PathBuf> {
+    config.log_file.as_ref().map(|f| project_root.join(f))
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
 
 #[derive(Parser)]
 struct Cli {
@@ -23,11 +87,6 @@ enum Command {
     PostCodegen,
     PreDev,
     PostDev,
-}
-
-fn log_path(_project_root: &std::path::Path) -> Option<std::path::PathBuf> {
-    // TODO load config and join log file path to project root
-    None
 }
 
 fn main() {
@@ -74,6 +133,10 @@ fn read_stdin<T: serde::de::DeserializeOwned>() -> T {
     serde_json::from_str(&buf).expect("failed to parse context JSON from stdin")
 }
 
+// ---------------------------------------------------------------------------
+// Hook handlers
+// ---------------------------------------------------------------------------
+
 fn cmd_pre_compile() {
     let ctx = read_stdin::<CompileContext>();
     let mut state = state::load(&ctx.project_root);
@@ -83,41 +146,61 @@ fn cmd_pre_compile() {
 
 fn cmd_post_compile() {
     let ctx = read_stdin::<CompileContext>();
+    let config = parse_config(ctx.config.as_ref());
     let mut state = state::load(&ctx.project_root);
-    let mut reporter = Reporter::new(log_path(&ctx.project_root).as_deref());
+    let mut reporter = Reporter::new(log_path(&ctx.project_root, &config).as_deref());
 
-    // Compile duration
-    if let Some(start) = state.compile_start {
-        let elapsed = state::elapsed_since(start);
-        reporter.log(&format!("📋 Compile time: {elapsed:.2}s"));
+    if config.verbosity == Verbosity::Standard {
+        // Compile duration
+        if let Some(start) = state.compile_start {
+            let elapsed = state::elapsed_since(start);
+            reporter.log(&format!("📋 Compile time: {elapsed:.2}s"));
+        }
+
+        // WASM sizes
+        reporter.log("📋 WASM sizes:");
+        for (name, path) in &ctx.wasm_paths {
+            let result = match std::fs::metadata(path) {
+                Ok(meta) => {
+                    let size = meta.len();
+                    // WASM files will be small enough for precision loss to not matter
+                    #[allow(clippy::cast_precision_loss)]
+                    let size_kb = size as f64 / 1024.0;
+                    let delta = state
+                        .prev_wasm_sizes
+                        .get(name)
+                        .map(|&prev| {
+                            let diff = i128::from(size) - i128::from(prev);
+                            match diff.cmp(&0) {
+                                std::cmp::Ordering::Greater => format!(" (▲{diff}B)"),
+                                std::cmp::Ordering::Less => {
+                                    format!(" (▼{}B)", diff.unsigned_abs())
+                                }
+                                std::cmp::Ordering::Equal => " (no change)".to_string(),
+                            }
+                        })
+                        .unwrap_or_default();
+                    format!("{name}: {size_kb:.1}KB{delta}")
+                }
+                Err(_) => String::from("(⚠️ WASM not found)"),
+            };
+            reporter.log(&format!("    • {result}"));
+        }
     }
 
-    // WASM size
-    reporter.log("📋 WASM sizes:");
-    for (name, path) in &ctx.wasm_paths {
-        let result = match std::fs::metadata(path) {
-            Ok(meta) => {
-                let size = meta.len();
-                // WASM files will be small enough for precision loss to not matter
+    // WASM size warnings — always emitted regardless of verbosity
+    if let Some(warn_kb) = config.warn_size_kb {
+        for (name, path) in &ctx.wasm_paths {
+            if let Ok(meta) = std::fs::metadata(path) {
                 #[allow(clippy::cast_precision_loss)]
-                let size_kb = size as f64 / 1024.0;
-                let delta = state
-                    .prev_wasm_sizes
-                    .get(name)
-                    .map(|&prev| {
-                        let diff = i128::from(size) - i128::from(prev);
-                        match diff.cmp(&0) {
-                            std::cmp::Ordering::Greater => format!(" (▲{diff}B)"),
-                            std::cmp::Ordering::Less => format!(" (▼{}B)", diff.unsigned_abs()),
-                            std::cmp::Ordering::Equal => " (no change)".to_string(),
-                        }
-                    })
-                    .unwrap_or_default();
-                format!("{name}: {size_kb:.1}KB{delta}")
+                let size_kb = meta.len() as f64 / 1024.0;
+                if size_kb > warn_kb {
+                    reporter.log(&format!(
+                        "⚠️  {name}: WASM size {size_kb:.1}KB exceeds threshold of {warn_kb:.0}KB"
+                    ));
+                }
             }
-            Err(_) => String::from("(⚠️ WASM not found)"),
-        };
-        reporter.log(&format!("    • {name}: {result}"));
+        }
     }
 
     // Update state for next build
@@ -136,8 +219,6 @@ fn cmd_post_compile() {
 
 fn cmd_pre_deploy() {
     let ctx = read_stdin::<DeployContext>();
-    let mut reporter = Reporter::new(log_path(&ctx.compile.project_root).as_deref());
-    reporter.log("📋 pre deploy hook");
     let mut state = state::load(&ctx.compile.project_root);
     state
         .deploy_start
@@ -147,29 +228,36 @@ fn cmd_pre_deploy() {
 
 fn cmd_post_deploy() {
     let ctx = read_stdin::<DeployContext>();
+    let config = parse_config(ctx.compile.config.as_ref());
     let mut state = state::load(&ctx.compile.project_root);
-    let mut reporter = Reporter::new(log_path(&ctx.compile.project_root).as_deref());
-    reporter.log("📋 post deploy hook");
+    let mut reporter = Reporter::new(log_path(&ctx.compile.project_root, &config).as_deref());
 
-    let elapsed = state.deploy_start.remove(&ctx.contract_name).map_or_else(
-        || "?".to_string(),
-        |start| format!("{:.2}s", state::elapsed_since(start)),
-    );
+    if config.verbosity == Verbosity::Standard {
+        let elapsed = state.deploy_start.remove(&ctx.contract_name).map_or_else(
+            || "?".to_string(),
+            |start| format!("{:.2}s", state::elapsed_since(start)),
+        );
 
-    let contract_id = ctx.contract_id.as_deref().unwrap_or("(unknown)");
+        let contract_id = ctx.contract_id.as_deref().unwrap_or("(unknown)");
+        let kind = match ctx.deploy_kind {
+            Some(DeployKind::Upgraded) => "upgraded in-place",
+            Some(DeployKind::Fresh) | None => "deployed fresh",
+        };
 
-    reporter.log(&format!(
-        "📋 Deployed {}:\n    id = {}\n    hash = {}\n    duration = {}",
-        ctx.contract_name, &contract_id, &ctx.wasm_hash, elapsed,
-    ));
+        reporter.log(&format!(
+            "📋 Deployed {} ({kind}):\n    id = {}\n    hash = {}\n    duration = {}",
+            ctx.contract_name, contract_id, &ctx.wasm_hash, elapsed,
+        ));
+    } else {
+        // Still remove the timer entry so state stays clean
+        state.deploy_start.remove(&ctx.contract_name);
+    }
 
     state::save(&ctx.compile.project_root, &state);
 }
 
 fn cmd_pre_codegen() {
     let ctx = read_stdin::<CodegenContext>();
-    let mut reporter = Reporter::new(log_path(&ctx.deploy.compile.project_root).as_deref());
-    reporter.log("📋 pre codegen hook");
     let mut state = state::load(&ctx.deploy.compile.project_root);
     state
         .codegen_start
@@ -179,25 +267,30 @@ fn cmd_pre_codegen() {
 
 fn cmd_post_codegen() {
     let ctx = read_stdin::<CodegenContext>();
+    let config = parse_config(ctx.deploy.compile.config.as_ref());
     let mut state = state::load(&ctx.deploy.compile.project_root);
-    let mut reporter = Reporter::new(log_path(&ctx.deploy.compile.project_root).as_deref());
-    reporter.log("📋 post codegen hook");
+    let mut reporter =
+        Reporter::new(log_path(&ctx.deploy.compile.project_root, &config).as_deref());
 
-    let elapsed = state
-        .codegen_start
-        .remove(&ctx.deploy.contract_name)
-        .map_or_else(
-            || "?".to_string(),
-            |start| format!("{:.2}s", state::elapsed_since(start)),
-        );
+    if config.verbosity == Verbosity::Standard {
+        let elapsed = state
+            .codegen_start
+            .remove(&ctx.deploy.contract_name)
+            .map_or_else(
+                || "?".to_string(),
+                |start| format!("{:.2}s", state::elapsed_since(start)),
+            );
 
-    // Sum the sizes of all files in ts_package_dir recursively
-    let ts_size_kb = dir_size_kb(&ctx.ts_package_dir);
+        // Sum the sizes of all files in ts_package_dir recursively
+        let ts_size_kb = dir_size_kb(&ctx.ts_package_dir);
 
-    reporter.log(&format!(
-        "📋 Codegen {}:\n    duration = {}\n    package size = {}",
-        ctx.deploy.contract_name, elapsed, ts_size_kb,
-    ));
+        reporter.log(&format!(
+            "📋 Codegen {}:\n    duration = {}\n    package size = {:.1}KB",
+            ctx.deploy.contract_name, elapsed, ts_size_kb,
+        ));
+    } else {
+        state.codegen_start.remove(&ctx.deploy.contract_name);
+    }
 
     state::save(&ctx.deploy.compile.project_root, &state);
 }
@@ -232,15 +325,32 @@ fn cmd_pre_dev() {
 
 fn cmd_post_dev() {
     let ctx = read_stdin::<ProjectContext>();
+    let config = parse_config(ctx.config.as_ref());
     let mut state = state::load(&ctx.project_root);
-    let mut reporter = Reporter::new(log_path(&ctx.project_root).as_deref());
+    let mut reporter = Reporter::new(log_path(&ctx.project_root, &config).as_deref());
 
     if let Some(start) = state.dev_start.take() {
         let elapsed = state::elapsed_since(start);
-        let contract_count = ctx.contracts.len();
-        reporter.log(&format!(
-            "📋 build cycle complete: {contract_count} contract(s) in {elapsed:.2}s"
-        ));
+
+        let (succeeded, failed): (Vec<_>, Vec<_>) =
+            ctx.contracts.iter().partition(|c| c.wasm_path.is_some());
+
+        let summary = if failed.is_empty() {
+            format!(
+                "📋 build cycle complete: {} contract(s) in {elapsed:.2}s",
+                succeeded.len()
+            )
+        } else {
+            let failed_names: Vec<&str> = failed.iter().map(|c| c.name.as_str()).collect();
+            format!(
+                "📋 build cycle complete: {} succeeded, {} failed ({}) in {elapsed:.2}s",
+                succeeded.len(),
+                failed.len(),
+                failed_names.join(", ")
+            )
+        };
+
+        reporter.log(&summary);
     }
 
     state::save(&ctx.project_root, &state);

--- a/crates/stellar-scaffold-reporter/src/main.rs
+++ b/crates/stellar-scaffold-reporter/src/main.rs
@@ -124,13 +124,36 @@ fn cmd_manifest() {
     println!("{}", serde_json::json!(manifest));
 }
 
-fn read_stdin<T: serde::de::DeserializeOwned>() -> T {
+/// Reads a context JSON from stdin and deserializes it.
+///
+/// Returns `None` on I/O or parse failure after logging a diagnostic to
+/// stderr. The reporter is a child process of scaffold; panicking or
+/// returning a non-zero exit would surface in scaffold's output as an
+/// extension error, so we degrade gracefully instead.
+fn read_stdin<T: serde::de::DeserializeOwned>() -> Option<T> {
     use std::io::Read;
     let mut buf = String::new();
-    std::io::stdin()
-        .read_to_string(&mut buf)
-        .expect("failed to read stdin");
-    serde_json::from_str(&buf).expect("failed to parse context JSON from stdin")
+    if let Err(e) = std::io::stdin().read_to_string(&mut buf) {
+        eprintln!("stellar-scaffold-reporter: failed to read stdin: {e}");
+        return None;
+    }
+    match serde_json::from_str(&buf) {
+        Ok(ctx) => Some(ctx),
+        Err(e) => {
+            eprintln!("stellar-scaffold-reporter: failed to parse context JSON: {e}");
+            None
+        }
+    }
+}
+
+/// Persist reporter state to disk, logging (but not propagating) I/O errors.
+///
+/// State loss only corrupts future deltas and timings, so a diagnostic is
+/// preferable to failing the hook.
+fn save_state(project_root: &std::path::Path, state: &state::State) {
+    if let Err(e) = state::save(project_root, state) {
+        eprintln!("stellar-scaffold-reporter: failed to save state: {e}");
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -138,14 +161,18 @@ fn read_stdin<T: serde::de::DeserializeOwned>() -> T {
 // ---------------------------------------------------------------------------
 
 fn cmd_pre_compile() {
-    let ctx = read_stdin::<CompileContext>();
+    let Some(ctx) = read_stdin::<CompileContext>() else {
+        return;
+    };
     let mut state = state::load(&ctx.project_root);
     state.compile_start = Some(state::now());
-    state::save(&ctx.project_root, &state);
+    save_state(&ctx.project_root, &state);
 }
 
 fn cmd_post_compile() {
-    let ctx = read_stdin::<CompileContext>();
+    let Some(ctx) = read_stdin::<CompileContext>() else {
+        return;
+    };
     let config = parse_config(ctx.config.as_ref());
     let mut state = state::load(&ctx.project_root);
     let mut reporter = Reporter::new(log_path(&ctx.project_root, &config).as_deref());
@@ -214,20 +241,24 @@ fn cmd_post_compile() {
         })
         .collect();
     state.compile_start = None;
-    state::save(&ctx.project_root, &state);
+    save_state(&ctx.project_root, &state);
 }
 
 fn cmd_pre_deploy() {
-    let ctx = read_stdin::<DeployContext>();
+    let Some(ctx) = read_stdin::<DeployContext>() else {
+        return;
+    };
     let mut state = state::load(&ctx.compile.project_root);
     state
         .deploy_start
         .insert(ctx.contract_name.clone(), state::now());
-    state::save(&ctx.compile.project_root, &state);
+    save_state(&ctx.compile.project_root, &state);
 }
 
 fn cmd_post_deploy() {
-    let ctx = read_stdin::<DeployContext>();
+    let Some(ctx) = read_stdin::<DeployContext>() else {
+        return;
+    };
     let config = parse_config(ctx.compile.config.as_ref());
     let mut state = state::load(&ctx.compile.project_root);
     let mut reporter = Reporter::new(log_path(&ctx.compile.project_root, &config).as_deref());
@@ -243,6 +274,8 @@ fn cmd_post_deploy() {
             Some(DeployKind::Upgraded) => "upgraded in-place",
             Some(DeployKind::Unchanged) => "unchanged",
             Some(DeployKind::Fresh) | None => "deployed fresh",
+            // DeployKind is #[non_exhaustive]; future variants default to this.
+            Some(_) => "deployed",
         };
 
         reporter.log(&format!(
@@ -254,20 +287,24 @@ fn cmd_post_deploy() {
         state.deploy_start.remove(&ctx.contract_name);
     }
 
-    state::save(&ctx.compile.project_root, &state);
+    save_state(&ctx.compile.project_root, &state);
 }
 
 fn cmd_pre_codegen() {
-    let ctx = read_stdin::<CodegenContext>();
+    let Some(ctx) = read_stdin::<CodegenContext>() else {
+        return;
+    };
     let mut state = state::load(&ctx.deploy.compile.project_root);
     state
         .codegen_start
         .insert(ctx.deploy.contract_name, state::now());
-    state::save(&ctx.deploy.compile.project_root, &state);
+    save_state(&ctx.deploy.compile.project_root, &state);
 }
 
 fn cmd_post_codegen() {
-    let ctx = read_stdin::<CodegenContext>();
+    let Some(ctx) = read_stdin::<CodegenContext>() else {
+        return;
+    };
     let config = parse_config(ctx.deploy.compile.config.as_ref());
     let mut state = state::load(&ctx.deploy.compile.project_root);
     let mut reporter =
@@ -293,7 +330,7 @@ fn cmd_post_codegen() {
         state.codegen_start.remove(&ctx.deploy.contract_name);
     }
 
-    state::save(&ctx.deploy.compile.project_root, &state);
+    save_state(&ctx.deploy.compile.project_root, &state);
 }
 
 /// Returns total size of all files under `dir` recursively, in KB.
@@ -318,14 +355,18 @@ fn dir_size_kb(dir: &std::path::Path) -> f64 {
 }
 
 fn cmd_pre_dev() {
-    let ctx = read_stdin::<ProjectContext>();
+    let Some(ctx) = read_stdin::<ProjectContext>() else {
+        return;
+    };
     let mut state = state::load(&ctx.project_root);
     state.dev_start = Some(state::now());
-    state::save(&ctx.project_root, &state);
+    save_state(&ctx.project_root, &state);
 }
 
 fn cmd_post_dev() {
-    let ctx = read_stdin::<ProjectContext>();
+    let Some(ctx) = read_stdin::<ProjectContext>() else {
+        return;
+    };
     let config = parse_config(ctx.config.as_ref());
     let mut state = state::load(&ctx.project_root);
     let mut reporter = Reporter::new(log_path(&ctx.project_root, &config).as_deref());
@@ -354,5 +395,5 @@ fn cmd_post_dev() {
         reporter.log(&summary);
     }
 
-    state::save(&ctx.project_root, &state);
+    save_state(&ctx.project_root, &state);
 }

--- a/crates/stellar-scaffold-reporter/src/report.rs
+++ b/crates/stellar-scaffold-reporter/src/report.rs
@@ -1,0 +1,31 @@
+use std::io::Write;
+use std::path::Path;
+
+pub struct Reporter {
+    log_file: Option<std::fs::File>,
+}
+
+impl Reporter {
+    /// Opens (or creates) the log file if `log_path` is Some.
+    pub fn new(log_path: Option<&Path>) -> Self {
+        let log_file = log_path.and_then(|p| {
+            if let Some(parent) = p.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(p)
+                .ok()
+        });
+        Self { log_file }
+    }
+
+    pub fn log(&mut self, line: &str) {
+        // TODO: write to stdout or file depending on config
+        println!("{line}");
+        if let Some(f) = &mut self.log_file {
+            let _ = writeln!(f, "{line}");
+        }
+    }
+}

--- a/crates/stellar-scaffold-reporter/src/report.rs
+++ b/crates/stellar-scaffold-reporter/src/report.rs
@@ -22,7 +22,6 @@ impl Reporter {
     }
 
     pub fn log(&mut self, line: &str) {
-        // TODO: write to stdout or file depending on config
         println!("{line}");
         if let Some(f) = &mut self.log_file {
             let _ = writeln!(f, "{line}");

--- a/crates/stellar-scaffold-reporter/src/state.rs
+++ b/crates/stellar-scaffold-reporter/src/state.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::io;
 use std::path::{Path, PathBuf};
 
 /// All mutable state the reporter perists between hook invocations.
@@ -34,13 +35,13 @@ pub fn load(project_root: &Path) -> State {
         .unwrap_or_default() // fall back to State::default() = all None/empty
 }
 
-pub fn save(project_root: &Path, state: &State) {
+pub fn save(project_root: &Path, state: &State) -> io::Result<()> {
     let path = state_path(project_root);
     if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent); // ignore error, save will fail anyway
+        std::fs::create_dir_all(parent)?;
     }
     let json = serde_json::to_string_pretty(state).expect("state serialization failed");
-    let _ = std::fs::write(&path, json);
+    std::fs::write(&path, json)
 }
 
 pub fn now() -> f64 {

--- a/crates/stellar-scaffold-reporter/src/state.rs
+++ b/crates/stellar-scaffold-reporter/src/state.rs
@@ -1,0 +1,55 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// All mutable state the reporter perists between hook invocations.
+/// Stored as JSON in `{project_root}/target/scaffold-reporter/state.json`.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct State {
+    /// Unix timestamp recorded at pre-compile.
+    pub compile_start: Option<f64>,
+
+    /// Unix timestamp recorded at pre-deploy, keyed by contract name.
+    pub deploy_start: BTreeMap<String, f64>,
+    /// Unix timestamp recorded at pre-codegen, keyed by contract name.
+    pub codegen_start: BTreeMap<String, f64>,
+    /// Unix timestamp recorded at pre-dev.
+    pub dev_start: Option<f64>,
+    /// WASM sizes (bytes) from the *previous* post-compile, keyed by contract name.
+    pub prev_wasm_sizes: BTreeMap<String, u64>,
+}
+
+fn state_path(project_root: &Path) -> PathBuf {
+    project_root
+        .join("target")
+        .join("scaffold-reporter")
+        .join("state.json")
+}
+
+pub fn load(project_root: &Path) -> State {
+    let path = state_path(project_root);
+    std::fs::read_to_string(&path)
+        .ok() // Option<String>: None if file missing
+        .and_then(|s| serde_json::from_str(&s).ok()) // Option<State>: None if parse fails
+        .unwrap_or_default() // fall back to State::default() = all None/empty
+}
+
+pub fn save(project_root: &Path, state: &State) {
+    let path = state_path(project_root);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent); // ignore error, save will fail anyway
+    }
+    let json = serde_json::to_string_pretty(state).expect("state serialization failed");
+    let _ = std::fs::write(&path, json);
+}
+
+pub fn now() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64()
+}
+
+pub fn elapsed_since(start: f64) -> f64 {
+    now() - start
+}

--- a/crates/stellar-scaffold-reporter/tests/integration.rs
+++ b/crates/stellar-scaffold-reporter/tests/integration.rs
@@ -86,18 +86,12 @@ log_file = "{log_path}"
             "package size missing"
         );
 
-        // post-dev: build cycle summary
-        assert!(
-            stdout.contains("📋 build cycle complete:"),
-            "post-dev summary missing"
-        );
-
-        // log file should exist and contain the same output
+        // log file should exist and contain build-phase output
         let log_file = env.cwd.join(log_path);
         assert!(log_file.exists(), "log file was not created");
         let log_content = std::fs::read_to_string(log_file).unwrap();
         assert!(log_content.contains("📋 Compile time:"));
-        assert!(log_content.contains("📋 build cycle complete:"));
+        assert!(log_content.contains("📋 Deployed soroban_hello_world_contract"));
     });
 }
 
@@ -142,12 +136,6 @@ warn_size_kb = 0.1
         );
 
         let stdout = String::from_utf8_lossy(&output.stdout);
-
-        // post-dev summary always fires
-        assert!(
-            stdout.contains("📋 build cycle complete:"),
-            "post-dev summary missing"
-        );
 
         // per-contract metrics suppressed at minimal verbosity
         assert!(

--- a/crates/stellar-scaffold-reporter/tests/integration.rs
+++ b/crates/stellar-scaffold-reporter/tests/integration.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration-tests")]
+
 use stellar_scaffold_test::{TestEnv, rpc_url};
 
 /// Returns a PATH string with the reporter binary's directory prepended so

--- a/justfile
+++ b/justfile
@@ -85,6 +85,10 @@ test-integration-scaffold-examples-2 ci="false":
 test-integration-registry ci="false":
     just _test-integration stellar-registry-cli 'test(/./)' {{ ci }}
 
+# Run reporter integration tests
+test-integration-reporter ci="false":
+    just _test-integration stellar-scaffold-reporter 'test(/./)' {{ ci }}
+
 create: build
     rm -rf .soroban
     -stellar keys generate default --fund

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 set dotenv-load := true
 
-export PATH := './target/bin:' + env_var('PATH')
+export PATH := './target/debug:./target/bin:' + env_var('PATH')
 export CONFIG_DIR := 'target/'
 export CI_BUILD := env_var_or_default('CI_BUILD', '')
 
@@ -13,6 +13,9 @@ scaffold +args:
 
 registry +args:
     @cargo run --bin stellar-registry --quiet -- {{ args }}
+
+reporter +args:
+    @cargo run --bin stellar-scaffold-reporter --quiet -- {{ args }}
 
 stellar-scaffold +args:
     @cargo run $CI_BUILD --bin stellar-scaffold -- {{ args }}

--- a/website/docs/extensions.md
+++ b/website/docs/extensions.md
@@ -87,7 +87,7 @@ At each hook invocation, Scaffold writes a flat JSON object to the extension's s
 ### Field reference
 
 | Field | pre/post-compile | pre/post-deploy | pre/post-codegen | pre/post-dev |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | `config` | ✓ | ✓ | ✓ | ✓ |
 | `project_root` | ✓ | ✓ | ✓ | ✓ |
 | `env` | ✓ | ✓ | ✓ | ✓ |
@@ -107,7 +107,7 @@ At each hook invocation, Scaffold writes a flat JSON object to the extension's s
 ### Field descriptions
 
 | Field | Type | Description |
-|---|---|---|
+| --- | --- | --- |
 | `config` | object \| null | Your extension's config table from `environments.toml`, or `null` |
 | `project_root` | string (path) | Absolute path to the Cargo workspace root |
 | `env` | string | Active environment: `"development"`, `"testing"`, `"staging"`, or `"production"` |
@@ -278,7 +278,7 @@ if (args[0] === "manifest") {
       name: "my-extension",
       version: "1.0.0",
       hooks: ["post-compile"],
-    })
+    }),
   );
 } else if (args[0] === "post-compile") {
   let input = "";

--- a/website/docs/extensions.md
+++ b/website/docs/extensions.md
@@ -1,0 +1,332 @@
+# Extensions
+
+Scaffold extensions let you tap into the build lifecycle without modifying Scaffold itself. An extension is an ordinary binary on your `PATH` named `stellar-scaffold-<name>`. Scaffold discovers it automatically, asks which hooks it cares about, and calls it at each of those points during a build or watch cycle.
+
+Extensions can do anything: log metrics, run audits, post Slack notifications, write custom artifacts, enforce size budgets, or generate extra files. They receive rich context about what just happened and can write anything they want to stdout, which Scaffold forwards to the user's terminal.
+
+---
+
+## Hook lifecycle
+
+Every build runs through the same ordered sequence of hooks:
+
+```
+pre-dev
+  └─ pre-compile
+       └─ [cargo build per contract]
+  └─ post-compile
+  └─ pre-deploy   (per contract)
+       └─ [upload wasm, deploy/upgrade contract]
+  └─ post-deploy  (per contract)
+  └─ pre-codegen  (per contract)
+       └─ [stellar contract bindings typescript + npm build]
+  └─ post-codegen (per contract)
+post-dev
+```
+
+The `pre-compile` and `post-compile` hooks fire once per build cycle, covering all contracts. The `pre-deploy`, `post-deploy`, `pre-codegen`, and `post-codegen` hooks fire once **per contract**. The `pre-dev` and `post-dev` hooks bookend the entire cycle.
+
+You only need to handle the hooks relevant to your extension. Hooks you do not list in your manifest are never invoked.
+
+---
+
+## Registering an extension
+
+Add your extension to `environments.toml` under the environments where it should run:
+
+```toml
+[development]
+extensions = ["reporter"]
+
+[staging]
+extensions = ["reporter", "audit-tool"]
+```
+
+### Per-extension configuration
+
+You can pass arbitrary configuration to an extension via `[<env>.ext.<name>]`:
+
+```toml
+[development.ext.reporter]
+warn_size_kb = 128
+log_file = ".scaffold/reports/dev.log"
+```
+
+Scaffold serializes this table and injects it as the `config` field in every hook invocation for that extension. If no config section exists, `config` is absent from the JSON.
+
+---
+
+## How Scaffold calls an extension
+
+1. **Discovery:** On startup, Scaffold runs `stellar-scaffold-<name> manifest` and parses the JSON response to learn which hooks the extension wants.
+2. **Invocation:** At each lifecycle point that the extension registered for, Scaffold runs `stellar-scaffold-<name> <hook-name>` and writes a JSON object to its stdin.
+3. **Output:** The extension reads stdin, does its work, writes anything it wants to stdout (forwarded to the user's terminal), and exits. A non-zero exit code is logged as an error, but Scaffold continues — remaining extensions registered for the same hook still run and the build is not aborted.
+
+---
+
+## The `manifest` subcommand
+
+Your binary must respond to `manifest` by writing a JSON object to stdout:
+
+```json
+{
+  "name": "my-extension",
+  "version": "1.0.0",
+  "hooks": ["post-compile", "post-deploy"]
+}
+```
+
+Only list hooks your extension actually handles. Listing a hook you do not handle wastes a subprocess invocation on every build. The `name` should match the suffix of your binary (`stellar-scaffold-my-extension` → `"my-extension"`).
+
+---
+
+## The stdin JSON
+
+At each hook invocation, Scaffold writes a flat JSON object to the extension's stdin. The object always includes `config` (your extension's config from `environments.toml`, or `null` if none was provided) plus context fields that depend on which hook is firing.
+
+### Field reference
+
+| Field | pre/post-compile | pre/post-deploy | pre/post-codegen | pre/post-dev |
+|---|---|---|---|---|
+| `config` | ✓ | ✓ | ✓ | ✓ |
+| `project_root` | ✓ | ✓ | ✓ | ✓ |
+| `env` | ✓ | ✓ | ✓ | ✓ |
+| `wasm_out_dir` | ✓ | ✓ | ✓ | ✓ |
+| `source_dirs` | ✓ | ✓ | ✓ | ✓ |
+| `wasm_paths` | ✓ (empty at pre) | ✓ | ✓ | — |
+| `network` | — | ✓ | ✓ | ✓ (if `--build-clients`) |
+| `contract_name` | — | ✓ | ✓ | — |
+| `wasm_path` | — | ✓ | ✓ | — |
+| `wasm_hash` | — | ✓ | ✓ | — |
+| `contract_id` | — | ✓ (`null` at pre) | ✓ | — |
+| `ts_package_dir` | — | — | ✓ | — |
+| `src_template_path` | — | — | ✓ | — |
+| `contracts` | — | — | — | ✓ |
+| `watch_paths` | — | — | — | ✓ |
+
+### Field descriptions
+
+| Field | Type | Description |
+|---|---|---|
+| `config` | object \| null | Your extension's config table from `environments.toml`, or `null` |
+| `project_root` | string (path) | Absolute path to the Cargo workspace root |
+| `env` | string | Active environment: `"development"`, `"testing"`, `"staging"`, or `"production"` |
+| `wasm_out_dir` | string (path) | Directory where compiled WASM files are written |
+| `source_dirs` | string[] | Contract source directories in topological build order |
+| `wasm_paths` | object | Map of `contract_name → wasm_path`; empty at `pre-compile` |
+| `network` | object \| null | Resolved RPC URL, network passphrase, and network name |
+| `contract_name` | string | Snake-case contract name matching the WASM filename stem |
+| `wasm_path` | string (path) | Absolute path to this contract's compiled WASM |
+| `wasm_hash` | string | Hex-encoded SHA-256 of the uploaded WASM bytecode |
+| `contract_id` | string \| null | Stellar contract address (`C…` strkey); `null` at `pre-deploy` |
+| `ts_package_dir` | string (path) | `<project_root>/packages/<name>/` |
+| `src_template_path` | string (path) | `<project_root>/src/contracts/<name>.ts` |
+| `contracts` | object[] | Per-contract summary array; optional fields are `null` at `pre-dev` |
+| `watch_paths` | string[] | Directories being watched; empty in one-shot builds |
+
+### Example: `post-compile` stdin
+
+```json
+{
+  "config": null,
+  "project_root": "/path/to/my-project",
+  "env": "development",
+  "wasm_out_dir": "/path/to/my-project/target/stellar/local",
+  "source_dirs": ["/path/to/my-project/contracts/hello_world"],
+  "wasm_paths": {
+    "hello_world": "/path/to/my-project/target/stellar/local/hello_world.wasm"
+  }
+}
+```
+
+### Example: `post-deploy` stdin
+
+```json
+{
+  "config": { "warn_size_kb": 128 },
+  "project_root": "/path/to/my-project",
+  "env": "development",
+  "wasm_out_dir": "/path/to/my-project/target/stellar/local",
+  "source_dirs": ["/path/to/my-project/contracts/hello_world"],
+  "wasm_paths": {
+    "hello_world": "/path/to/my-project/target/stellar/local/hello_world.wasm"
+  },
+  "network": {
+    "rpc_url": "http://localhost:8000/soroban/rpc",
+    "network_passphrase": "Standalone Network ; February 2017",
+    "network_name": "local"
+  },
+  "contract_name": "hello_world",
+  "wasm_path": "/path/to/my-project/target/stellar/local/hello_world.wasm",
+  "wasm_hash": "a1b2c3d4e5f6...",
+  "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4"
+}
+```
+
+---
+
+## Building an extension
+
+### Step 1: Create a binary crate
+
+```sh
+cargo new --bin stellar-scaffold-my-extension
+cd stellar-scaffold-my-extension
+```
+
+### Step 2: Implement the `manifest` subcommand
+
+Your binary must handle `manifest` as its first argument and print JSON to stdout:
+
+```sh
+stellar-scaffold-my-extension manifest
+```
+
+```json
+{
+  "name": "my-extension",
+  "version": "1.0.0",
+  "hooks": ["post-compile", "post-deploy"]
+}
+```
+
+Only list the hooks you actually handle.
+
+### Step 3: Implement hook handlers
+
+For each hook you listed, handle the corresponding subcommand argument. Read the full stdin JSON, do your work, and print output for the user:
+
+```sh
+stellar-scaffold-my-extension post-compile
+# (JSON on stdin)
+```
+
+### Step 4: Install it on PATH
+
+Scaffold discovers extensions by looking for binaries named `stellar-scaffold-<name>` on your `PATH`. For Rust extensions, install with Cargo:
+
+```sh
+cargo install --path .
+```
+
+Or copy the compiled binary somewhere on your `PATH`.
+
+### Step 5: Register it in `environments.toml`
+
+```toml
+[development]
+extensions = ["my-extension"]
+```
+
+Run `stellar scaffold build` or `stellar scaffold watch` and your extension will be called at each registered hook.
+
+---
+
+## Language-specific examples
+
+### Rust
+
+Use the [`stellar-scaffold-ext-types`](https://crates.io/crates/stellar-scaffold-ext-types) crate for typed access to the stdin JSON:
+
+```toml
+[dependencies]
+stellar-scaffold-ext-types = "0.0.1"
+serde_json = "1"
+```
+
+```rust
+use std::io::Read;
+use stellar_scaffold_ext_types::{ExtensionManifest, HookName, CompileContext};
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    match args.get(1).map(String::as_str) {
+        Some("manifest") => {
+            let manifest = ExtensionManifest {
+                name: "my-extension".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                hooks: vec![HookName::PostCompile.as_str().to_string()],
+            };
+            println!("{}", serde_json::to_string(&manifest).unwrap());
+        }
+        Some("post-compile") => {
+            let mut buf = String::new();
+            std::io::stdin().read_to_string(&mut buf).unwrap();
+            let ctx: CompileContext = serde_json::from_str(&buf).unwrap();
+            println!("Compiled {} contracts:", ctx.wasm_paths.len());
+            for (name, path) in &ctx.wasm_paths {
+                println!("  {name}: {}", path.display());
+            }
+        }
+        _ => {}
+    }
+}
+```
+
+The `ext-types` crate uses `#[serde(flatten)]` so the Rust structs compose naturally while the wire format stays flat. See the [crate README](https://github.com/theahaco/scaffold-stellar/tree/main/crates/stellar-scaffold-ext-types) for the full type reference.
+
+### TypeScript / Node.js
+
+```ts
+import * as readline from "readline";
+
+const args = process.argv.slice(2);
+
+if (args[0] === "manifest") {
+  console.log(
+    JSON.stringify({
+      name: "my-extension",
+      version: "1.0.0",
+      hooks: ["post-compile"],
+    })
+  );
+} else if (args[0] === "post-compile") {
+  let input = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk) => (input += chunk));
+  process.stdin.on("end", () => {
+    const ctx = JSON.parse(input);
+    const names = Object.keys(ctx.wasm_paths);
+    console.log(`Compiled ${names.length} contracts: ${names.join(", ")}`);
+  });
+}
+```
+
+Install it by putting the script on your `PATH` (via a shebang + `chmod +x`, a compiled bundle with `pkg` or `bun build --compile`, etc.) and naming it `stellar-scaffold-my-extension`.
+
+### Any other language
+
+Extensions are just binaries. Use whatever language you want. The only requirements are:
+
+- The binary is named `stellar-scaffold-<name>` and is on your `PATH`
+- Running it with `manifest` prints a JSON manifest to stdout
+- Running it with a hook name reads JSON from stdin and exits with code 0 on success
+
+---
+
+## The Scaffold Reporter
+
+`stellar-scaffold-reporter` is the canonical reference implementation. It is the built-in extension that ships with every `stellar scaffold init` project and demonstrates the full hook lifecycle in practice.
+
+It tracks and logs:
+
+- **Compile time** — how long `cargo build` took
+- **WASM sizes** — byte size of each contract's `.wasm` output, with delta from the previous build
+- **Deploy info** — contract ID, WASM hash, and deploy duration per contract
+- **TypeScript package size** — total size of the generated client package
+- **Total build cycle duration** — end-to-end time from `pre-dev` to `post-dev`
+
+You can install it standalone with:
+
+```sh
+cargo install stellar-scaffold-reporter
+```
+
+And register it in `environments.toml`:
+
+```toml
+[development]
+extensions = ["reporter"]
+```
+
+Browse the [source code](https://github.com/theahaco/scaffold-stellar/tree/main/crates/stellar-scaffold-reporter) and its [README](https://github.com/theahaco/scaffold-stellar/tree/main/crates/stellar-scaffold-reporter/README.md) to see a complete, real-world extension that handles all eight hooks.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -32,6 +32,7 @@ const sidebars: SidebarsConfig = {
     },
     "cli",
     "environments",
+    "extensions",
     "registry",
     "deploy",
   ],


### PR DESCRIPTION
Adds the reference extension `stellar-scaffold-reporter` using all the new hooks for Scaffold:
- It reports compile timing, Wasm sizes with deltas, deploy details, codegen timing, a summary after each life-cycle phase
- This cleans up the current build output so nothing is duplicated (fixes #328). Now scaffold logging is only essentials (i.e. successes, warnings, errors).
- Adds configured modes "standard" and "minimal" to quiet the output even more
- Adds extension system tests using the reporter

Closes #449 