### PR TITLE
docs(contracts/registry): link other repos

### DIFF
--- a/contracts/registry/README.md
+++ b/contracts/registry/README.md
@@ -1,5 +1,11 @@
 # stellar-registry
 
+The missing infrastructure layer between "I wrote a smart contract" and "the ecosystem can safely use my smart contract."
+
+- Smart Contract source code: this repository; this folder
+- Frontend source code: [theahaco/registry-ui](https://github.com/theahaco/registry-ui)
+- Indexer & API: [theahaco/registry-indexer](https://github.com/theahaco/registry-indexer)
+
 `stellar-registry` is a Rust crate for managing and deploying smart contracts on the Soroban blockchain. It provides an easy-to-use interface for developers to interact with the blockchain and deploy their smart contracts without dealing with low-level implementation details.
 
 ## Features


### PR DESCRIPTION
The [Public Goods form](https://github.com/SCF-Public-Goods-Maintenance/scf-public-goods-maintenance.github.io/issues/new?template=pg-award-proposal-form.yml) only allows listing one repository, but Registry has a few. This lists them at the top, so we can link people just to this one and they can quickly find the others.