### PR TITLE
fix: address review findings on reporter extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4449,7 +4449,6 @@ dependencies = [
  "serde_json",
  "stellar-scaffold-ext-types",
  "stellar-scaffold-test",
- "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/crates/stellar-scaffold-ext-types/src/lib.rs
+++ b/crates/stellar-scaffold-ext-types/src/lib.rs
@@ -46,6 +46,7 @@ use serde::{Deserialize, Serialize};
 /// etc.). Use [`HookName::as_str`] to compare against manifest entries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum HookName {
     /// Fired once before `cargo build` runs for any contract.
     PreCompile,
@@ -205,6 +206,7 @@ pub struct CompileContext {
 /// Always `None` at `pre-deploy` (the action has not yet occurred).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum DeployKind {
     /// The contract was instantiated for the first time (new contract ID).
     Fresh,

--- a/crates/stellar-scaffold-reporter/Cargo.toml
+++ b/crates/stellar-scaffold-reporter/Cargo.toml
@@ -18,7 +18,6 @@ stellar-scaffold-ext-types = { path = "../stellar-scaffold-ext-types" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 clap = { version = "4", features = ["derive"] }
-thiserror = "2"
 
 [dev-dependencies]
 assert_cmd = "2.1.1"

--- a/crates/stellar-scaffold-reporter/src/main.rs
+++ b/crates/stellar-scaffold-reporter/src/main.rs
@@ -124,13 +124,36 @@ fn cmd_manifest() {
     println!("{}", serde_json::json!(manifest));
 }
 
-fn read_stdin<T: serde::de::DeserializeOwned>() -> T {
+/// Reads a context JSON from stdin and deserializes it.
+///
+/// Returns `None` on I/O or parse failure after logging a diagnostic to
+/// stderr. The reporter is a child process of scaffold; panicking or
+/// returning a non-zero exit would surface in scaffold's output as an
+/// extension error, so we degrade gracefully instead.
+fn read_stdin<T: serde::de::DeserializeOwned>() -> Option<T> {
     use std::io::Read;
     let mut buf = String::new();
-    std::io::stdin()
-        .read_to_string(&mut buf)
-        .expect("failed to read stdin");
-    serde_json::from_str(&buf).expect("failed to parse context JSON from stdin")
+    if let Err(e) = std::io::stdin().read_to_string(&mut buf) {
+        eprintln!("stellar-scaffold-reporter: failed to read stdin: {e}");
+        return None;
+    }
+    match serde_json::from_str(&buf) {
+        Ok(ctx) => Some(ctx),
+        Err(e) => {
+            eprintln!("stellar-scaffold-reporter: failed to parse context JSON: {e}");
+            None
+        }
+    }
+}
+
+/// Persist reporter state to disk, logging (but not propagating) I/O errors.
+///
+/// State loss only corrupts future deltas and timings, so a diagnostic is
+/// preferable to failing the hook.
+fn save_state(project_root: &std::path::Path, state: &state::State) {
+    if let Err(e) = state::save(project_root, state) {
+        eprintln!("stellar-scaffold-reporter: failed to save state: {e}");
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -138,14 +161,18 @@ fn read_stdin<T: serde::de::DeserializeOwned>() -> T {
 // ---------------------------------------------------------------------------
 
 fn cmd_pre_compile() {
-    let ctx = read_stdin::<CompileContext>();
+    let Some(ctx) = read_stdin::<CompileContext>() else {
+        return;
+    };
     let mut state = state::load(&ctx.project_root);
     state.compile_start = Some(state::now());
-    state::save(&ctx.project_root, &state);
+    save_state(&ctx.project_root, &state);
 }
 
 fn cmd_post_compile() {
-    let ctx = read_stdin::<CompileContext>();
+    let Some(ctx) = read_stdin::<CompileContext>() else {
+        return;
+    };
     let config = parse_config(ctx.config.as_ref());
     let mut state = state::load(&ctx.project_root);
     let mut reporter = Reporter::new(log_path(&ctx.project_root, &config).as_deref());
@@ -214,20 +241,24 @@ fn cmd_post_compile() {
         })
         .collect();
     state.compile_start = None;
-    state::save(&ctx.project_root, &state);
+    save_state(&ctx.project_root, &state);
 }
 
 fn cmd_pre_deploy() {
-    let ctx = read_stdin::<DeployContext>();
+    let Some(ctx) = read_stdin::<DeployContext>() else {
+        return;
+    };
     let mut state = state::load(&ctx.compile.project_root);
     state
         .deploy_start
         .insert(ctx.contract_name.clone(), state::now());
-    state::save(&ctx.compile.project_root, &state);
+    save_state(&ctx.compile.project_root, &state);
 }
 
 fn cmd_post_deploy() {
-    let ctx = read_stdin::<DeployContext>();
+    let Some(ctx) = read_stdin::<DeployContext>() else {
+        return;
+    };
     let config = parse_config(ctx.compile.config.as_ref());
     let mut state = state::load(&ctx.compile.project_root);
     let mut reporter = Reporter::new(log_path(&ctx.compile.project_root, &config).as_deref());
@@ -243,6 +274,8 @@ fn cmd_post_deploy() {
             Some(DeployKind::Upgraded) => "upgraded in-place",
             Some(DeployKind::Unchanged) => "unchanged",
             Some(DeployKind::Fresh) | None => "deployed fresh",
+            // DeployKind is #[non_exhaustive]; future variants default to this.
+            Some(_) => "deployed",
         };
 
         reporter.log(&format!(
@@ -254,20 +287,24 @@ fn cmd_post_deploy() {
         state.deploy_start.remove(&ctx.contract_name);
     }
 
-    state::save(&ctx.compile.project_root, &state);
+    save_state(&ctx.compile.project_root, &state);
 }
 
 fn cmd_pre_codegen() {
-    let ctx = read_stdin::<CodegenContext>();
+    let Some(ctx) = read_stdin::<CodegenContext>() else {
+        return;
+    };
     let mut state = state::load(&ctx.deploy.compile.project_root);
     state
         .codegen_start
         .insert(ctx.deploy.contract_name, state::now());
-    state::save(&ctx.deploy.compile.project_root, &state);
+    save_state(&ctx.deploy.compile.project_root, &state);
 }
 
 fn cmd_post_codegen() {
-    let ctx = read_stdin::<CodegenContext>();
+    let Some(ctx) = read_stdin::<CodegenContext>() else {
+        return;
+    };
     let config = parse_config(ctx.deploy.compile.config.as_ref());
     let mut state = state::load(&ctx.deploy.compile.project_root);
     let mut reporter =
@@ -293,7 +330,7 @@ fn cmd_post_codegen() {
         state.codegen_start.remove(&ctx.deploy.contract_name);
     }
 
-    state::save(&ctx.deploy.compile.project_root, &state);
+    save_state(&ctx.deploy.compile.project_root, &state);
 }
 
 /// Returns total size of all files under `dir` recursively, in KB.
@@ -318,14 +355,18 @@ fn dir_size_kb(dir: &std::path::Path) -> f64 {
 }
 
 fn cmd_pre_dev() {
-    let ctx = read_stdin::<ProjectContext>();
+    let Some(ctx) = read_stdin::<ProjectContext>() else {
+        return;
+    };
     let mut state = state::load(&ctx.project_root);
     state.dev_start = Some(state::now());
-    state::save(&ctx.project_root, &state);
+    save_state(&ctx.project_root, &state);
 }
 
 fn cmd_post_dev() {
-    let ctx = read_stdin::<ProjectContext>();
+    let Some(ctx) = read_stdin::<ProjectContext>() else {
+        return;
+    };
     let config = parse_config(ctx.config.as_ref());
     let mut state = state::load(&ctx.project_root);
     let mut reporter = Reporter::new(log_path(&ctx.project_root, &config).as_deref());
@@ -354,5 +395,5 @@ fn cmd_post_dev() {
         reporter.log(&summary);
     }
 
-    state::save(&ctx.project_root, &state);
+    save_state(&ctx.project_root, &state);
 }

--- a/crates/stellar-scaffold-reporter/src/report.rs
+++ b/crates/stellar-scaffold-reporter/src/report.rs
@@ -22,7 +22,6 @@ impl Reporter {
     }
 
     pub fn log(&mut self, line: &str) {
-        // TODO: write to stdout or file depending on config
         println!("{line}");
         if let Some(f) = &mut self.log_file {
             let _ = writeln!(f, "{line}");

--- a/crates/stellar-scaffold-reporter/src/state.rs
+++ b/crates/stellar-scaffold-reporter/src/state.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::io;
 use std::path::{Path, PathBuf};
 
 /// All mutable state the reporter perists between hook invocations.
@@ -34,13 +35,13 @@ pub fn load(project_root: &Path) -> State {
         .unwrap_or_default() // fall back to State::default() = all None/empty
 }
 
-pub fn save(project_root: &Path, state: &State) {
+pub fn save(project_root: &Path, state: &State) -> io::Result<()> {
     let path = state_path(project_root);
     if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent); // ignore error, save will fail anyway
+        std::fs::create_dir_all(parent)?;
     }
     let json = serde_json::to_string_pretty(state).expect("state serialization failed");
-    let _ = std::fs::write(&path, json);
+    std::fs::write(&path, json)
 }
 
 pub fn now() -> f64 {


### PR DESCRIPTION
Follow-up to #463. Addresses five narrow findings from a deep review of the reporter extension, scoped to uncontroversial fixes. Larger changes (signal handling, state locking, verbose-gating removed output, `build.rs` workaround, negative-path tests) are deliberately left for follow-up PRs.

## Summary

- **`state::save` now returns `io::Result<()>`** and callers log failures via a `save_state` helper instead of silently dropping state writes with `let _ =`. State loss previously corrupted size deltas and elapsed-time readings on the next build with no signal.
- **`read_stdin` returns `Option<T>`**; the reporter logs a diagnostic to stderr and degrades gracefully on bad input instead of panicking (which surfaces in scaffold's output as a non-zero extension exit and fails the whole build).
- **`HookName` and `DeployKind` are marked `#[non_exhaustive]`** so adding a hook or deploy kind in the future is not a breaking change for external extension authors consuming `stellar-scaffold-ext-types`. The author already hand-coded forward-compat for `ExtensionManifest::hooks: Vec<String>` (per the doc comment on that field) — this extends the same policy to the enum layer. `ExtensionManifest` itself is left exhaustive since the documented pattern in `website/docs/extensions.md` and `ext-types/README.md` uses a struct literal, and field additions to a three-field manifest are unlikely.
- **Drop unused `thiserror` dependency** from `stellar-scaffold-reporter/Cargo.toml` (confirmed zero references in reporter source).
- **Remove stale `TODO` comment** in `report.rs` whose behavior is already correct (config gating happens at the call sites).

## Out of scope (follow-ups)

- Signal handling / child-process cleanup on `SIGINT` in `extension.rs`
- `target/scaffold-reporter/state.json` concurrent-build locking
- Decision on re-gating informational output removed in 05b8bc4 behind `--verbose`
- Feature-gating or restructuring the `build.rs` `CARGO_BIN_EXE_…` workaround
- Negative-path integration tests (missing binary, crashing hook, deadlocked stdin)

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `just build`
- [x] `just clippy-test` (pedantic, all-features, all-targets)
- [x] `cargo test -p stellar-scaffold-reporter --features integration-tests` (both `reporter_standard_output` and `reporter_minimal_output` pass)
- [x] `cargo test -p stellar-scaffold-cli --lib extension` (all 15 extension unit tests pass)
- [x] `cargo test -p stellar-scaffold-cli --test it --features integration-tests features::extensions` (`extension_hooks_fire_in_order` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)