### PR TITLE
fix: rename the name registered contract to root

### DIFF
--- a/contracts/registry/src/registry/contract.rs
+++ b/contracts/registry/src/registry/contract.rs
@@ -198,7 +198,7 @@ impl Contract {
                 }
                 .publish(env);
                 events::SubRegistry {
-                    name: registry(env).to_string(),
+                    name: String::from_str(env, "root"),
                     contract_id: env.current_contract_address(),
                 }
                 .publish(env);


### PR DESCRIPTION
A Quick fix to the registry contract. Currently it emits a SubRegistry event and names itself 'registry' this is a bit overloaded and considering that `is_root` is the option it should be renamed to match.