### PR TITLE
Feat/pkg manager improvements

### DIFF
--- a/crates/stellar-scaffold-cli/src/commands/build/clients.rs
+++ b/crates/stellar-scaffold-cli/src/commands/build/clients.rs
@@ -421,7 +421,7 @@ export default new Client.Client({{
                     "--network-passphrase",
                     &network.network_passphrase,
                 ])?;
-                bindings_cmd.execute(self.global_args.quiet).await?;
+                bindings_cmd.execute(true).await?;
 
                 printer.infoln(format!(
                     "Running '{pm_label} install' in {temp_dir_display:?}"

--- a/crates/stellar-scaffold-cli/src/commands/init.rs
+++ b/crates/stellar-scaffold-cli/src/commands/init.rs
@@ -165,20 +165,17 @@ impl Cmd {
         let pm_command = pkg_manager.kind.command();
         let install_succeeded = run_install(pm_command, &absolute_project_path, &printer);
 
-        // Build contracts and create contract clients
-        printer.infoln("Building contracts and generating client code...");
-        // Use clap to parse build command with defaults, then configure programmatically
-        let mut build_command = build::Command::parse_from(["build", "--build-clients"]);
+        // Compile contracts only — client generation requires a live network and is handled by `start`
+        printer.infoln("Compiling contracts...");
+        let mut build_command = build::Command::parse_from(["build"]);
         build_command.build.manifest_path = Some(absolute_project_path.join("Cargo.toml"));
-        build_command.build_clients_args.env = Some(build::clients::ScaffoldEnv::Development);
-        build_command.build_clients_args.workspace_root = Some(absolute_project_path.clone());
         let mut build_args = global_args.clone();
         if !(global_args.verbose && global_args.very_verbose) {
             build_args.quiet = true;
         }
 
         if let Err(e) = build_command.run(&build_args).await {
-            printer.warnln(format!("Failed to build contract clients: {e}"));
+            printer.warnln(format!("Failed to compile contracts: {e}"));
         }
 
         // If git is installed, run init and make initial commit

--- a/crates/stellar-scaffold-cli/src/commands/init.rs
+++ b/crates/stellar-scaffold-cli/src/commands/init.rs
@@ -25,6 +25,10 @@ pub struct Cmd {
 
     #[command(flatten)]
     vers: Vers,
+
+    /// Specify package manager, omitting will prompt interactively
+    #[arg(short = 'p', long)]
+    pub package_manager: Option<PackageManager>,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -123,7 +127,16 @@ impl Cmd {
             }
         }
 
-        let Some(pkg_manager) = select_pkg_manager(&printer) else {
+        let Some(pkg_manager) = (match &self.package_manager {
+            Some(kind) => {
+                let version = pkg_manager_version(kind.command());
+                Some(PackageManagerSpec {
+                    kind: kind.clone(),
+                    version,
+                })
+            }
+            None => select_pkg_manager(&printer),
+        }) else {
             printer.warnln("Package manager selection cancelled. Run the command again to retry.");
             return Ok(());
         };
@@ -186,7 +199,7 @@ impl Cmd {
             printer.blankln(format!("\t{pm_command} install"));
         }
         printer.blankln(format!("\t{pm_command} start"));
-        printer.blankln(" Happy hacking! 🚀");
+        printer.blankln("\n Happy hacking! 🚀");
         Ok(())
     }
 

--- a/crates/stellar-scaffold-cli/src/commands/init.rs
+++ b/crates/stellar-scaffold-cli/src/commands/init.rs
@@ -16,6 +16,10 @@ const TUTORIAL_BRANCH: &str = "tutorial";
 const PNPM_WORKSPACE: &str = r#"packages:
   - "packages/*"
 "#;
+const DENO_CONFIG: &str = r#"{
+  "nodeModulesDir": "auto"
+}
+"#;
 
 /// A command to initialize a new project
 #[derive(Parser, Debug, Clone)]
@@ -141,14 +145,24 @@ impl Cmd {
             return Ok(());
         };
 
-        if pkg_manager.kind == PackageManager::Pnpm {
-            if let Err(e) = write(
-                absolute_project_path.join("pnpm-workspace.yaml"),
-                PNPM_WORKSPACE,
-            ) {
-                printer.warnln(format!("Failed to create pnpm-workspace.yaml: {e}"));
+        match pkg_manager.kind {
+            PackageManager::Pnpm => {
+                if let Err(e) = write(
+                    absolute_project_path.join("pnpm-workspace.yaml"),
+                    PNPM_WORKSPACE,
+                ) {
+                    printer.warnln(format!("Failed to create pnpm-workspace.yaml: {e}"));
+                }
             }
-        } else if pkg_manager.kind != PackageManager::Npm
+            PackageManager::Deno => {
+                if let Err(e) = write(absolute_project_path.join("deno.json"), DENO_CONFIG) {
+                    printer.warnln(format!("Failed to create deno.json: {e}"));
+                }
+            }
+            _ => {}
+        }
+
+        if pkg_manager.kind != PackageManager::Npm
             && let Err(e) = remove_file(absolute_project_path.join("package-lock.json"))
         {
             printer.warnln(format!("Failed to remove package-lock.json: {e}"));

--- a/crates/stellar-scaffold-cli/src/commands/init.rs
+++ b/crates/stellar-scaffold-cli/src/commands/init.rs
@@ -1,7 +1,7 @@
 use clap::{Args, Parser};
 use degit::degit;
-use dialoguer::Select;
 use dialoguer::theme::ColorfulTheme;
+use dialoguer::{Confirm, Select};
 use std::fs::{copy, metadata, read_dir, remove_dir_all, remove_file, write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -9,6 +9,7 @@ use std::{env, io};
 
 use super::{build, generate};
 use crate::commands::{PackageManager, PackageManagerSpec};
+use crate::extension::{ExtensionListStatus, list as list_extensions};
 use stellar_cli::{commands::global, print::Print};
 
 pub const FRONTEND_TEMPLATE: &str = "theahaco/scaffold-stellar-frontend";
@@ -115,6 +116,9 @@ impl Cmd {
                 absolute_project_path.display()
             )));
         }
+
+        // Check extensions listed in environments.toml and offer to install any that are missing
+        ensure_extensions_installed(&absolute_project_path, &printer);
 
         // Copy .env.example to .env
         let example_path = absolute_project_path.join(".env.example");
@@ -377,6 +381,115 @@ fn run_install(pm_command: &str, path: &Path, printer: &Print) -> bool {
         Err(e) => {
             printer.warnln(format!("Failed to run {pm_command} install: {e}"));
             false
+        }
+    }
+}
+
+/// Official extensions and their install commands.
+const KNOWN_EXTENSIONS: &[(&str, &str)] =
+    &[("reporter", "cargo install stellar-scaffold-reporter")];
+
+/// Reads `environments.toml` from the cloned project, collects all unique
+/// extensions across every environment, checks which binaries are missing from
+/// PATH, and — if any are absent — offers a single prompt to install known ones
+/// and warns about any others. Non-fatal: warnings are printed on failure.
+fn ensure_extensions_installed(project_path: &Path, printer: &Print) {
+    let env_toml_path = project_path.join("environments.toml");
+    let Ok(toml_str) = std::fs::read_to_string(&env_toml_path) else {
+        return; // no environments.toml, nothing to check
+    };
+
+    let Ok(mut envs) = toml::from_str::<
+        std::collections::HashMap<String, build::env_toml::Environment>,
+    >(&toml_str) else {
+        printer.warnln("Could not parse environments.toml to check extensions");
+        return;
+    };
+
+    // Collect unique extension entries across all environments
+    let mut seen = std::collections::HashSet::new();
+    let unique_entries: Vec<_> = envs
+        .values_mut()
+        .flat_map(|env| env.extensions.drain(..))
+        .filter(|e| seen.insert(e.name.clone()))
+        .collect();
+
+    if unique_entries.is_empty() {
+        return;
+    }
+
+    let missing: Vec<String> = list_extensions(&unique_entries)
+        .into_iter()
+        .filter(|e| matches!(e.status, ExtensionListStatus::MissingBinary))
+        .map(|e| e.name)
+        .collect();
+
+    if missing.is_empty() {
+        return;
+    }
+
+    let (known, unknown): (Vec<_>, Vec<_>) = missing
+        .iter()
+        .partition(|name| KNOWN_EXTENSIONS.iter().any(|(k, _)| k == name));
+
+    if !unknown.is_empty() {
+        printer.warnln(format!(
+            "Missing 3rd party extensions: {}",
+            unknown
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+        printer.warnln("Install manually and ensure 'stellar-scaffold-<name>' is on your PATH.");
+    }
+
+    if known.is_empty() {
+        return;
+    }
+
+    printer.infoln(format!(
+        "Missing official extensions: {}",
+        known
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    ));
+
+    let install = Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt("Install missing extensions?")
+        .default(true)
+        .interact()
+        .unwrap_or(false);
+
+    if !install {
+        printer.warnln("Skipped extension installation. Some features may not work until extensions are installed.");
+        return;
+    }
+
+    for name in &known {
+        let install_cmd = KNOWN_EXTENSIONS
+            .iter()
+            .find(|(k, _)| k == name)
+            .map(|(_, cmd)| *cmd)
+            .unwrap();
+
+        printer.infoln(format!("Running: {install_cmd}"));
+        let mut parts = install_cmd.split_whitespace();
+        let bin = parts.next().unwrap();
+        let args: Vec<_> = parts.collect();
+        match Command::new(bin).args(&args).output() {
+            Ok(output) if output.status.success() => {
+                printer.checkln(format!("'{name}' installed"));
+            }
+            Ok(output) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                printer.warnln(format!("Failed to install '{name}': {}", stderr.trim()));
+            }
+            Err(e) => {
+                printer.warnln(format!("Failed to run '{install_cmd}': {e}"));
+            }
         }
     }
 }

--- a/crates/stellar-scaffold-cli/src/commands/init.rs
+++ b/crates/stellar-scaffold-cli/src/commands/init.rs
@@ -34,6 +34,10 @@ pub struct Cmd {
     /// Specify package manager, omitting will prompt interactively
     #[arg(short = 'p', long)]
     pub package_manager: Option<PackageManager>,
+
+    /// Accept all defaults and skip interactive prompts
+    #[arg(short = 'y', long)]
+    pub yes: bool,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -118,7 +122,7 @@ impl Cmd {
         }
 
         // Check extensions listed in environments.toml and offer to install any that are missing
-        ensure_extensions_installed(&absolute_project_path, &printer);
+        ensure_extensions_installed(&absolute_project_path, &printer, self.yes);
 
         // Copy .env.example to .env
         let example_path = absolute_project_path.join(".env.example");
@@ -143,7 +147,7 @@ impl Cmd {
                     version,
                 })
             }
-            None => select_pkg_manager(&printer),
+            None => select_pkg_manager(&printer, self.yes),
         }) else {
             printer.warnln("Package manager selection cancelled. Run the command again to retry.");
             return Ok(());
@@ -299,7 +303,7 @@ fn detect_pkg_managers() -> Vec<PackageManagerSpec> {
 /// Interactively pick a package manager. Shows only installed managers with their
 /// detected versions. Defaults to npm if available, otherwise the first detected.
 /// Returns `None` if the user cancels (Ctrl+C) or no managers are found.
-fn select_pkg_manager(printer: &Print) -> Option<PackageManagerSpec> {
+fn select_pkg_manager(printer: &Print, yes: bool) -> Option<PackageManagerSpec> {
     let detected = detect_pkg_managers();
 
     if detected.is_empty() {
@@ -311,18 +315,18 @@ fn select_pkg_manager(printer: &Print) -> Option<PackageManagerSpec> {
         });
     }
 
-    if detected.len() == 1 {
-        let spec = detected.into_iter().next().unwrap();
-        let label = format_pm_label(&spec);
-        printer.infoln(format!("Using {label} (only package manager detected)"));
-        return Some(spec);
-    }
-
     // Default selection: prefer npm, otherwise use the first detected manager
     let default_index = detected
         .iter()
         .position(|s| s.kind == PackageManager::Npm)
         .unwrap_or(0);
+
+    if yes || detected.len() == 1 {
+        let spec = detected.into_iter().nth(default_index).unwrap();
+        let label = format_pm_label(&spec);
+        printer.infoln(format!("Using {label}"));
+        return Some(spec);
+    }
 
     let labels: Vec<String> = detected.iter().map(format_pm_label).collect();
 
@@ -393,7 +397,7 @@ const KNOWN_EXTENSIONS: &[(&str, &str)] =
 /// extensions across every environment, checks which binaries are missing from
 /// PATH, and — if any are absent — offers a single prompt to install known ones
 /// and warns about any others. Non-fatal: warnings are printed on failure.
-fn ensure_extensions_installed(project_path: &Path, printer: &Print) {
+fn ensure_extensions_installed(project_path: &Path, printer: &Print, yes: bool) {
     let env_toml_path = project_path.join("environments.toml");
     let Ok(toml_str) = std::fs::read_to_string(&env_toml_path) else {
         return; // no environments.toml, nothing to check
@@ -457,11 +461,12 @@ fn ensure_extensions_installed(project_path: &Path, printer: &Print) {
             .join(", ")
     ));
 
-    let install = Confirm::with_theme(&ColorfulTheme::default())
-        .with_prompt("Install missing extensions?")
-        .default(true)
-        .interact()
-        .unwrap_or(false);
+    let install = yes
+        || Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt("Install missing extensions?")
+            .default(true)
+            .interact()
+            .unwrap_or(false);
 
     if !install {
         printer.warnln("Skipped extension installation. Some features may not work until extensions are installed.");

--- a/crates/stellar-scaffold-cli/src/commands/mod.rs
+++ b/crates/stellar-scaffold-cli/src/commands/mod.rs
@@ -218,7 +218,8 @@ pub enum PackageManager {
 }
 
 impl PackageManager {
-    pub const LIST: &'static [Self] = &[Self::Npm, Self::Pnpm, Self::Yarn, Self::Bun, Self::Deno];
+    // Deno omitted — uses `deno task` not `deno run`, requires separate implementation
+    pub const LIST: &'static [Self] = &[Self::Npm, Self::Pnpm, Self::Yarn, Self::Bun];
 
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -235,8 +236,8 @@ impl PackageManager {
             Self::Npm => Self::os_specific_command("npm"),
             Self::Pnpm => Self::os_specific_command("pnpm"),
             Self::Yarn => Self::os_specific_command("yarn"),
-            Self::Bun => "bun",
-            Self::Deno => "deno",
+            // bun and deno ship as native binaries on all platforms, no .cmd wrapper needed
+            Self::Bun | Self::Deno => self.as_str(),
         }
     }
 
@@ -259,8 +260,8 @@ impl PackageManager {
         match self {
             Self::Npm => cmd.args(["install", "--loglevel=error"]),
             Self::Pnpm => cmd.args(["install", "--reporter=silent"]),
-            Self::Yarn => cmd.args(["install", "--silent"]),
-            _ => cmd.args(["install"]),
+            Self::Yarn | Self::Bun => cmd.args(["install", "--silent"]),
+            Self::Deno => cmd.args(["install"]),
         };
         cmd.output()
     }
@@ -274,7 +275,10 @@ impl PackageManager {
             Self::Pnpm => cmd.args(["install", "--ignore-workspace", "--reporter=silent"]),
             // yarn classic: --ignore-workspace-root-check skips workspace root enforcement
             Self::Yarn => cmd.args(["install", "--ignore-workspace-root-check", "--silent"]),
-            _ => cmd.args(["install"]),
+            // bun only treats dirs as workspace members if listed in package.json workspaces field,
+            // so plain install in a generated temp dir is already workspace-isolated
+            Self::Bun => cmd.args(["install", "--silent"]),
+            Self::Deno => cmd.args(["install"]),
         };
         cmd.output()
     }
@@ -285,7 +289,7 @@ impl PackageManager {
         match self {
             Self::Npm => cmd.arg("--loglevel=error"),
             Self::Pnpm => cmd.arg("--reporter=silent"),
-            _ => &mut cmd,
+            Self::Yarn | Self::Bun | Self::Deno => &mut cmd,
         };
         cmd.output()
     }
@@ -393,7 +397,6 @@ mod tests {
         #[case(PackageManager::Pnpm, Some("9.6.0".to_string()))]
         #[case(PackageManager::Yarn, None)]
         #[case(PackageManager::Bun, Some("1.1.0".to_string()))]
-        #[case(PackageManager::Deno, Some("2.0.0".to_string()))]
         fn package_json_round_trip(#[case] pm: PackageManager, #[case] version: Option<String>) {
             let dir = tempfile::tempdir().unwrap();
             let pkg_path = dir.path().join("package.json");

--- a/crates/stellar-scaffold-cli/src/commands/mod.rs
+++ b/crates/stellar-scaffold-cli/src/commands/mod.rs
@@ -207,7 +207,7 @@ fn set_package_manager_field(json: &str, value: &str) -> Option<String> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, clap::ValueEnum)]
 pub enum PackageManager {
     Npm,
     Pnpm,

--- a/crates/stellar-scaffold-cli/src/commands/mod.rs
+++ b/crates/stellar-scaffold-cli/src/commands/mod.rs
@@ -363,4 +363,51 @@ mod tests {
         assert!(result.contains(r#""scripts""#));
         assert!(result.contains(r#""packageManager": "bun@1.0.0""#));
     }
+
+    mod parameterized {
+        use super::*;
+        use rstest::rstest;
+
+        #[rstest]
+        #[case(PackageManager::Npm, "npm")]
+        #[case(PackageManager::Pnpm, "pnpm")]
+        #[case(PackageManager::Yarn, "yarn")]
+        #[case(PackageManager::Bun, "bun")]
+        #[case(PackageManager::Deno, "deno")]
+        fn as_str_matches_name(#[case] pm: PackageManager, #[case] expected: &str) {
+            assert_eq!(pm.as_str(), expected);
+        }
+
+        #[rstest]
+        #[case(PackageManager::Npm)]
+        #[case(PackageManager::Pnpm)]
+        #[case(PackageManager::Yarn)]
+        #[case(PackageManager::Bun)]
+        #[case(PackageManager::Deno)]
+        fn command_contains_name(#[case] pm: PackageManager) {
+            assert!(pm.command().contains(pm.as_str()));
+        }
+
+        #[rstest]
+        #[case(PackageManager::Npm, Some("11.0.0".to_string()))]
+        #[case(PackageManager::Pnpm, Some("9.6.0".to_string()))]
+        #[case(PackageManager::Yarn, None)]
+        #[case(PackageManager::Bun, Some("1.1.0".to_string()))]
+        #[case(PackageManager::Deno, Some("2.0.0".to_string()))]
+        fn package_json_round_trip(#[case] pm: PackageManager, #[case] version: Option<String>) {
+            let dir = tempfile::tempdir().unwrap();
+            let pkg_path = dir.path().join("package.json");
+            std::fs::write(&pkg_path, "{\n  \"name\": \"test-app\"\n}").unwrap();
+
+            let spec = PackageManagerSpec { kind: pm, version };
+            spec.write_to_package_json(dir.path()).unwrap();
+
+            let contents = std::fs::read_to_string(&pkg_path).unwrap();
+            assert!(serde_json::from_str::<serde_json::Value>(&contents).is_ok());
+
+            let recovered = PackageManagerSpec::from_package_json(dir.path()).unwrap();
+            assert_eq!(recovered.kind, spec.kind);
+            assert_eq!(recovered.version, spec.version);
+        }
+    }
 }

--- a/crates/stellar-scaffold-cli/src/commands/mod.rs
+++ b/crates/stellar-scaffold-cli/src/commands/mod.rs
@@ -198,12 +198,13 @@ fn set_package_manager_field(json: &str, value: &str) -> Option<String> {
         let insert_pos = json.rfind('}')?;
         let before = &json[..insert_pos];
         let after = &json[insert_pos..];
-        let comma = if before.trim_end().ends_with(',') {
+        let before_trimmed = before.trim_end();
+        let comma = if before_trimmed.ends_with(',') {
             ""
         } else {
             ","
         };
-        Some(format!("{before}{comma}\n  {replacement}\n{after}"))
+        Some(format!("{before_trimmed}{comma}\n  {replacement}\n{after}"))
     }
 }
 
@@ -343,6 +344,16 @@ mod tests {
         let result = set_package_manager_field(json, "npm@11.0.0").unwrap();
         assert!(result.contains(r#""packageManager": "npm@11.0.0""#));
         assert!(result.contains(r#""name": "foo""#));
+        assert!(serde_json::from_str::<serde_json::Value>(&result).is_ok());
+    }
+
+    #[test]
+    fn set_package_manager_field_inserts_produces_valid_json() {
+        // real-world multi-line package.json with trailing newline before closing brace
+        let json = "{\n  \"name\": \"my-app\",\n  \"version\": \"1.0.0\"\n}";
+        let result = set_package_manager_field(json, "pnpm@9.6.0").unwrap();
+        assert!(serde_json::from_str::<serde_json::Value>(&result).is_ok());
+        assert!(result.contains("\"packageManager\": \"pnpm@9.6.0\""));
     }
 
     #[test]

--- a/crates/stellar-scaffold-cli/src/commands/mod.rs
+++ b/crates/stellar-scaffold-cli/src/commands/mod.rs
@@ -218,8 +218,7 @@ pub enum PackageManager {
 }
 
 impl PackageManager {
-    // Deno omitted — uses `deno task` not `deno run`, requires separate implementation
-    pub const LIST: &'static [Self] = &[Self::Npm, Self::Pnpm, Self::Yarn, Self::Bun];
+    pub const LIST: &'static [Self] = &[Self::Npm, Self::Pnpm, Self::Yarn, Self::Bun, Self::Deno];
 
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -261,7 +260,7 @@ impl PackageManager {
             Self::Npm => cmd.args(["install", "--loglevel=error"]),
             Self::Pnpm => cmd.args(["install", "--reporter=silent"]),
             Self::Yarn | Self::Bun => cmd.args(["install", "--silent"]),
-            Self::Deno => cmd.args(["install"]),
+            Self::Deno => cmd.args(["install", "--quiet"]),
         };
         cmd.output()
     }
@@ -275,21 +274,23 @@ impl PackageManager {
             Self::Pnpm => cmd.args(["install", "--ignore-workspace", "--reporter=silent"]),
             // yarn classic: --ignore-workspace-root-check skips workspace root enforcement
             Self::Yarn => cmd.args(["install", "--ignore-workspace-root-check", "--silent"]),
-            // bun only treats dirs as workspace members if listed in package.json workspaces field,
-            // so plain install in a generated temp dir is already workspace-isolated
+            // bun and deno workspaces are opt-in via their config files, so temp dirs are
+            // already isolated without extra flags
             Self::Bun => cmd.args(["install", "--silent"]),
-            Self::Deno => cmd.args(["install"]),
+            Self::Deno => cmd.args(["install", "--quiet"]),
         };
         cmd.output()
     }
 
     pub(crate) fn build(&self, dir: &Path) -> io::Result<Output> {
         let mut cmd = Command::new(self.command());
-        cmd.current_dir(dir).args(["run", "build"]);
+        cmd.current_dir(dir);
         match self {
-            Self::Npm => cmd.arg("--loglevel=error"),
-            Self::Pnpm => cmd.arg("--reporter=silent"),
-            Self::Yarn | Self::Bun | Self::Deno => &mut cmd,
+            Self::Npm => cmd.args(["run", "build", "--loglevel=error"]),
+            Self::Pnpm => cmd.args(["run", "build", "--reporter=silent"]),
+            Self::Yarn | Self::Bun => cmd.args(["run", "build"]),
+            // deno uses `task` not `run` to execute package.json scripts
+            Self::Deno => cmd.args(["task", "build"]),
         };
         cmd.output()
     }


### PR DESCRIPTION
Adds a bunch of improvements to the package manager feature:
- Fixes comma formatting issue when adding `packageManager` field to package.json
- Adds support for Bun
- Adds support for Deno
- Adds unit tests for new utilities supporting package manager choice (e.g. which are installed? what's listed in package.json?)
- Stifles a hardcoded print line including "npm" from stellar cli's contract binding command
- Adds a flag to specify package manager on init and skip prompt
- Adds a prompt to install missing extensions listed in environments.toml
- Adds a flag to skip all prompts on init and use defaults