### PR TITLE
feat: registry intake issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/registry-admin.yml
+++ b/.github/ISSUE_TEMPLATE/registry-admin.yml
@@ -1,0 +1,111 @@
+name: "Registry: Admin op (manage / upgrade contract)"
+description: Request a sensitive op — change owner/address/name of a registered contract, or upgrade a deployed contract.
+title: "Registry Admin: "
+labels: ["registry-intake", "registry-intake:admin"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Registry Admin Intake (high-sensitivity)
+
+        Use this form for sensitive operations on already-registered or already-deployed
+        contracts. **Higher quorum applies** (see `.github/registry-quorum.yml`).
+
+        Only fill in the fields that apply to your chosen `method`. The validator will
+        reject submissions where required fields for that method are missing.
+
+        > **Out of scope for v1:** `set_admin`, `set_manager`, `remove_manager`, and
+        > registry-self `upgrade` all require **registry admin** auth, not the CI key.
+        > Those operations remain offline-only — see `docs/ci-publishing.md`.
+
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network
+      options:
+        - testnet
+        - mainnet
+    validations:
+      required: true
+
+  - type: dropdown
+    id: method
+    attributes:
+      label: Method
+      description: |
+        - `update_contract_owner` — change the owner of a registry entry.
+        - `update_contract_address` — point a registered name at a new contract address.
+        - `rename_contract` — rename a registry entry.
+        - `upgrade_contract` — upgrade a deployed contract to a different published wasm.
+      options:
+        - update_contract_owner
+        - update_contract_address
+        - rename_contract
+        - upgrade_contract
+    validations:
+      required: true
+
+  - type: input
+    id: contract_name
+    attributes:
+      label: Contract name (target)
+      description: The name of the registered contract being modified.
+      placeholder: e.g. hello, unverified/my-thing
+    validations:
+      required: true
+
+  - type: input
+    id: new_owner
+    attributes:
+      label: New owner (G… or C…) — `update_contract_owner` only
+      description: Required for `update_contract_owner`. Leave blank otherwise.
+      placeholder: G...56 or C...56
+    validations:
+      required: false
+
+  - type: input
+    id: new_address
+    attributes:
+      label: New contract address (C…) — `update_contract_address` only
+      description: Required for `update_contract_address`. Leave blank otherwise.
+      placeholder: C...56
+    validations:
+      required: false
+
+  - type: input
+    id: new_name
+    attributes:
+      label: New name — `rename_contract` only
+      description: Required for `rename_contract`. Use `unverified/<name>` for the unverified subregistry. Leave blank otherwise.
+      placeholder: e.g. hello-renamed
+    validations:
+      required: false
+
+  - type: input
+    id: wasm_name
+    attributes:
+      label: Wasm name — `upgrade_contract` only
+      description: Required for `upgrade_contract`. The published wasm name to upgrade to.
+      placeholder: e.g. hello, unverified/hello
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Wasm version — `upgrade_contract` only
+      description: Optional even for `upgrade_contract`. Leave blank to upgrade to the latest published version.
+      placeholder: e.g. 0.2.0
+    validations:
+      required: false
+
+  - type: textarea
+    id: justification
+    attributes:
+      label: Justification
+      description: |
+        High-sensitivity ops. Explain why this is needed, who has reviewed the change,
+        what testing has been done, and what the rollback plan is. Pilots use this to
+        decide whether to react 👍.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/registry-deploy.yml
+++ b/.github/ISSUE_TEMPLATE/registry-deploy.yml
@@ -1,0 +1,90 @@
+name: "Registry: Deploy contract"
+description: Request that a published wasm be deployed and registered under a name
+title: "Registry Deploy: "
+labels: ["registry-intake", "registry-intake:deploy"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Registry Deploy Intake
+
+        Use this form to request that a previously published wasm be deployed (instantiated)
+        and registered under a contract name on-chain.
+
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network
+      options:
+        - testnet
+        - mainnet
+    validations:
+      required: true
+
+  - type: input
+    id: wasm_name
+    attributes:
+      label: Wasm name
+      description: Name of the previously-published wasm to deploy.
+      placeholder: e.g. hello, unverified/hello
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Wasm version
+      description: Semver of the published wasm. Optional — leave blank to deploy the latest.
+      placeholder: e.g. 0.1.0
+    validations:
+      required: false
+
+  - type: input
+    id: contract_name
+    attributes:
+      label: Contract name
+      description: Name to register the deployed contract under. Use `unverified/<name>` for unverified subregistry.
+      placeholder: e.g. hello, unverified/my-hello
+    validations:
+      required: true
+
+  - type: input
+    id: admin
+    attributes:
+      label: Admin address (G… or C…)
+      description: Account or contract that will be set as admin of the deployed contract.
+      placeholder: G...56 or C...56
+    validations:
+      required: true
+
+  - type: textarea
+    id: constructor_args
+    attributes:
+      label: Constructor args (after `--`)
+      description: |
+        Extra args passed to the contract's `__constructor` after `--`. One `--name=value`
+        per line. Leave blank if the contract has no extra constructor parameters.
+      placeholder: |
+        --token=CTOKEN...
+        --fee_bps=30
+    validations:
+      required: false
+
+  - type: input
+    id: deployer
+    attributes:
+      label: Deployer address (G…)
+      description: Optional. Defaults to the registry contract itself.
+      placeholder: G...56
+    validations:
+      required: false
+
+  - type: textarea
+    id: justification
+    attributes:
+      label: Justification
+      description: |
+        Why should this wasm be deployed under this name? Has the wasm been reviewed?
+        Pilots use this to decide whether to react 👍.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/registry-publish.yml
+++ b/.github/ISSUE_TEMPLATE/registry-publish.yml
@@ -1,0 +1,100 @@
+name: "Registry: Publish wasm"
+description: Request a wasm hash (or full wasm) be published to the on-chain registry
+title: "Registry Publish: "
+labels: ["registry-intake", "registry-intake:publish"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Registry Publish Intake
+
+        Use this form to request that a wasm be recorded on the on-chain registry under a
+        name and version. Once a quorum of `registry-pilots` reacts 👍 and a pilot comments
+        `.quorum-check`, the on-chain submit workflow will run from a protected environment.
+
+        - For *trusted* names (no prefix), the registry's manager (CI key) will sign on behalf
+          of the author. For *unverified* names, prefix the wasm name with `unverified/`.
+        - Versions must be valid semver (`MAJOR.MINOR.PATCH`) and strictly greater than the
+          current on-chain version for the same name.
+
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network
+      description: Which network to publish to.
+      options:
+        - testnet
+        - mainnet
+    validations:
+      required: true
+
+  - type: dropdown
+    id: method
+    attributes:
+      label: Method
+      description: |
+        - `publish_hash` — record an already-uploaded wasm by its hash. Lower trust burden,
+          since the hash is supplied directly. **Recommended default.**
+        - `publish` — fetch the wasm from `wasm_url`, upload it, and record it. The workflow
+          will compute and verify the hash matches `wasm_hash`.
+      options:
+        - publish_hash
+        - publish
+    validations:
+      required: true
+
+  - type: input
+    id: wasm_name
+    attributes:
+      label: Wasm name
+      description: kebab-case. Use `unverified/<name>` to publish to the unverified subregistry.
+      placeholder: e.g. hello, unverified/hello, oz/fungible
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Semver. Must be strictly greater than the current on-chain version.
+      placeholder: e.g. 0.1.0
+    validations:
+      required: true
+
+  - type: input
+    id: wasm_hash
+    attributes:
+      label: Wasm hash (sha256, hex, 64 chars)
+      description: Required for `publish_hash`. For `publish`, optional — the workflow will compute and cross-check.
+      placeholder: 64-character hex string
+    validations:
+      required: false
+
+  - type: input
+    id: wasm_url
+    attributes:
+      label: Wasm release URL
+      description: Required for `publish` only. Direct URL to the optimized .wasm artifact (e.g. a GitHub release asset).
+      placeholder: https://github.com/owner/repo/releases/download/v0.1.0/contract.wasm
+    validations:
+      required: false
+
+  - type: input
+    id: author
+    attributes:
+      label: Author address (G…)
+      description: Stellar account address that will be recorded as the wasm's author. Optional — defaults to the CI signer if blank.
+      placeholder: G...56
+    validations:
+      required: false
+
+  - type: textarea
+    id: justification
+    attributes:
+      label: Justification
+      description: |
+        What is this wasm? What changed since the last published version? Who reviewed
+        the source offline (link reviews, audit reports, commit ranges)? Pilots use this
+        to decide whether to react 👍.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/registry-register.yml
+++ b/.github/ISSUE_TEMPLATE/registry-register.yml
@@ -1,0 +1,59 @@
+name: "Registry: Register existing contract"
+description: Request that an already-deployed contract be registered under a name in the registry
+title: "Registry Register: "
+labels: ["registry-intake", "registry-intake:register"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Registry Register-Contract Intake
+
+        Use this form to request that an existing on-chain contract be registered under
+        a name in the on-chain registry. The contract must already be deployed.
+
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network
+      options:
+        - testnet
+        - mainnet
+    validations:
+      required: true
+
+  - type: input
+    id: contract_name
+    attributes:
+      label: Contract name
+      description: kebab-case. Use `unverified/<name>` to register under the unverified subregistry.
+      placeholder: e.g. soroswap, unverified/my-thing
+    validations:
+      required: true
+
+  - type: input
+    id: contract_address
+    attributes:
+      label: Contract address (C…)
+      description: The on-chain address of the deployed contract being registered.
+      placeholder: C...56
+    validations:
+      required: true
+
+  - type: input
+    id: owner
+    attributes:
+      label: Owner address (G… or C…)
+      description: Account that will own this registry entry. Optional — defaults to the CI signer if blank.
+      placeholder: G...56 or C...56
+    validations:
+      required: false
+
+  - type: textarea
+    id: justification
+    attributes:
+      label: Justification
+      description: |
+        Why should this contract be registered under this name? Who controls the contract?
+        Has it been audited? Pilots use this to decide whether to react 👍.
+    validations:
+      required: true


### PR DESCRIPTION
Add four issue-form templates for on-chain registry method requests:
publish, register, deploy, and admin (the high-sensitivity kind that
covers update_contract_owner/address, rename_contract, and
upgrade_contract).

Each form applies `registry-intake` plus a kind subtype label
(`registry-intake:publish` etc.) at creation time. No workflows
consume these labels yet — that lands in follow-up commits.

Testable after merge: visit "New issue", confirm the four templates
render, fill one out, confirm both labels appear on the created
issue. No validation, no votes — just form intake.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>