### PR TITLE
feat: validate registry intake forms in CI

### DIFF
--- a/.github/scripts/render_validation_failure.py
+++ b/.github/scripts/render_validation_failure.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Render issue-ops/validator's `errors` JSON output into a friendly markdown comment.
+
+Reads `COMMENT_ERRORS` from the environment (a JSON string emitted by
+`issue-ops/validator@v4`'s `errors` output) and prints a markdown body to stdout.
+The caller pipes that into `gh issue comment --body-file -`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def main() -> int:
+    raw = os.environ.get("COMMENT_ERRORS", "").strip()
+    if not raw:
+        print(":x: Validation failed but no error details were emitted by the validator.")
+        return 0
+
+    try:
+        errors = json.loads(raw)
+    except json.JSONDecodeError:
+        print(":x: Validation failed. Raw validator output:\n\n```\n" + raw + "\n```")
+        return 0
+
+    if not isinstance(errors, list) or not errors:
+        print(":x: Validation failed but the error list was empty or malformed.")
+        return 0
+
+    lines = [
+        ":x: **Validation failed.** Please edit the issue to fix the problems below — the form will be re-validated automatically.",
+        "",
+    ]
+    for err in errors:
+        if isinstance(err, dict):
+            field = err.get("field") or err.get("name") or "(field)"
+            msg = err.get("message") or err.get("error") or json.dumps(err)
+            lines.append(f"- **`{field}`** — {msg}")
+        else:
+            lines.append(f"- {err}")
+    lines.append("")
+    lines.append(
+        "Once you've edited the fields, the `issueops:validation-error` label will be removed and the issue will move to `registry-intake:in-review`."
+    )
+
+    print("\n".join(lines))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/validator/config.yml
+++ b/.github/validator/config.yml
@@ -1,0 +1,42 @@
+# issue-ops/validator@v4 config. Each entry maps an issue-form field id to a
+# validator script under this directory. Empty values pass — required-ness is
+# enforced by the form template's `validations: required: true`.
+#
+# All four registry intake forms share this config. Fields that don't exist on
+# a particular form are skipped automatically.
+validators:
+  # Wasm/contract names (kebab-case with optional `prefix/`).
+  - field: wasm_name
+    script: validate-contract-name.js
+  - field: contract_name
+    script: validate-contract-name.js
+  - field: new_name
+    script: validate-contract-name.js
+
+  # Stellar strkey addresses — accepts G… (account) or C… (contract).
+  - field: author
+    script: validate-stellar-strkey.js
+  - field: contract_address
+    script: validate-stellar-strkey.js
+  - field: owner
+    script: validate-stellar-strkey.js
+  - field: admin
+    script: validate-stellar-strkey.js
+  - field: deployer
+    script: validate-stellar-strkey.js
+  - field: new_owner
+    script: validate-stellar-strkey.js
+  - field: new_address
+    script: validate-stellar-strkey.js
+
+  # Wasm hash — sha256 hex, 64 chars.
+  - field: wasm_hash
+    script: validate-wasm-hash.js
+
+  # Semver MAJOR.MINOR.PATCH (with optional pre-release/build metadata).
+  - field: version
+    script: validate-semver.js
+
+  # Wasm release URL — https only.
+  - field: wasm_url
+    script: validate-https-url.js

--- a/.github/validator/validate-contract-name.js
+++ b/.github/validator/validate-contract-name.js
@@ -1,0 +1,16 @@
+module.exports = async (field) => {
+  if (!field || typeof field !== 'string') return 'success';
+  const value = field.trim();
+  if (value.length === 0) return 'success';
+  // Optional `<prefix>/` then a kebab-or-snake segment. Each segment must
+  // start with a lowercase letter and contain only [a-z0-9_-]. Length capped
+  // at 64 chars total to match the registry's name storage policy.
+  const re = /^([a-z][a-z0-9_-]*\/)?[a-z][a-z0-9_-]*$/;
+  if (!re.test(value)) {
+    return 'name must be kebab- or snake-case (lowercase letters, digits, `_`, `-`), optionally prefixed with `<subregistry>/`. Examples: `hello`, `unverified/my-thing`, `oz/fungible_token`.';
+  }
+  if (value.length > 64) {
+    return `name exceeds 64 characters (current: ${value.length}).`;
+  }
+  return 'success';
+};

--- a/.github/validator/validate-https-url.js
+++ b/.github/validator/validate-https-url.js
@@ -1,0 +1,10 @@
+module.exports = async (field) => {
+  if (!field || typeof field !== 'string') return 'success';
+  const value = field.trim();
+  if (value.length === 0) return 'success';
+  const re = /^https:\/\/[^\s/$.?#].[^\s]*$/i;
+  if (!re.test(value)) {
+    return 'URL must start with `https://` and be a well-formed URL.';
+  }
+  return 'success';
+};

--- a/.github/validator/validate-semver.js
+++ b/.github/validator/validate-semver.js
@@ -1,0 +1,14 @@
+module.exports = async (field) => {
+  if (!field || typeof field !== 'string') return 'success';
+  const value = field.trim();
+  if (value.length === 0) return 'success';
+  // Semver per https://semver.org with optional pre-release and build metadata.
+  // The registry stores versions as opaque strings but enforces strict ordering
+  // on publish, so an invalid semver here will be rejected later — better to
+  // catch it at the form stage.
+  const re = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+  if (!re.test(value)) {
+    return 'version must be valid semver (`MAJOR.MINOR.PATCH`, optionally with pre-release and build metadata). Examples: `0.1.0`, `1.2.3-rc.1`, `2.0.0+build.5`.';
+  }
+  return 'success';
+};

--- a/.github/validator/validate-stellar-strkey.js
+++ b/.github/validator/validate-stellar-strkey.js
@@ -1,0 +1,14 @@
+module.exports = async (field) => {
+  if (!field || typeof field !== 'string') return 'success';
+  const value = field.trim();
+  if (value.length === 0) return 'success';
+  // Stellar strkey: 56 chars, base32 alphabet (A-Z, 2-7), version byte
+  // determines kind. We accept G (ed25519 account) or C (contract).
+  // Muxed M and signed-payload P are intentionally rejected for these fields —
+  // the registry methods take account/contract addresses, not muxed.
+  const re = /^[GC][A-Z2-7]{55}$/;
+  if (!re.test(value)) {
+    return 'must be a 56-character Stellar strkey starting with `G` (account) or `C` (contract). Example: `GABC…56-chars` or `CABC…56-chars`.';
+  }
+  return 'success';
+};

--- a/.github/validator/validate-wasm-hash.js
+++ b/.github/validator/validate-wasm-hash.js
@@ -1,0 +1,12 @@
+module.exports = async (field) => {
+  if (!field || typeof field !== 'string') return 'success';
+  const value = field.trim();
+  if (value.length === 0) return 'success';
+  // sha256 — 32 bytes, hex-encoded → 64 lowercase hex chars (case-insensitive
+  // accepted; the on-chain registry stores it as bytes regardless).
+  const re = /^[0-9a-fA-F]{64}$/;
+  if (!re.test(value)) {
+    return `wasm hash must be a 64-character hex sha256 (current length: ${value.length}). No \`0x\` prefix. Example: \`a1b2…64-chars\`.`;
+  }
+  return 'success';
+};

--- a/.github/workflows/validate-registry-intake.yml
+++ b/.github/workflows/validate-registry-intake.yml
@@ -1,0 +1,120 @@
+name: Validate Registry Intake
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  validate:
+    if: contains(github.event.issue.labels.*.name, 'registry-intake')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clear previous state labels
+        # Kind subtype labels (registry-intake:publish/register/deploy/admin) are
+        # applied by the form template itself and are NOT cleared here — they
+        # persist for the lifetime of the issue.
+        uses: issue-ops/labeler@v4
+        with:
+          action: remove
+          issue_number: ${{ github.event.issue.number }}
+          labels: |
+            registry-intake:in-review
+            registry-intake:accepted
+            registry-intake:rejected
+            registry-intake:submitted
+            registry-intake:submission-failed
+            issueops:validation-error
+
+      - name: Resolve form kind and template
+        id: kind
+        env:
+          LABELS_JSON: ${{ toJSON(github.event.issue.labels) }}
+        run: |
+          set -euo pipefail
+          KIND=$(jq -r '
+            .[].name
+            | select(startswith("registry-intake:"))
+            | sub("^registry-intake:"; "")
+            | select(. == "publish" or . == "register" or . == "deploy" or . == "admin")
+          ' <<<"$LABELS_JSON" | head -n 1)
+          if [ -z "${KIND:-}" ]; then
+            echo "::error::Issue has the parent `registry-intake` label but no kind subtype (publish/register/deploy/admin). The form template should set both."
+            exit 1
+          fi
+          case "$KIND" in
+            publish)  TEMPLATE=registry-publish.yml ;;
+            register) TEMPLATE=registry-register.yml ;;
+            deploy)   TEMPLATE=registry-deploy.yml ;;
+            admin)    TEMPLATE=registry-admin.yml ;;
+          esac
+          echo "kind=$KIND" >> "$GITHUB_OUTPUT"
+          echo "template=$TEMPLATE" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repo (for validator scripts and form templates)
+        uses: actions/checkout@v6
+
+      - name: Parse intake form
+        id: parse
+        uses: issue-ops/parser@v5
+        with:
+          body: ${{ github.event.issue.body }}
+          issue-form-template: ${{ steps.kind.outputs.template }}
+
+      - name: Validate intake form
+        id: validate
+        uses: issue-ops/validator@v4
+        with:
+          issue-form-template: ${{ steps.kind.outputs.template }}
+          parsed-issue-body: ${{ steps.parse.outputs.json }}
+          add-comment: false
+
+      - name: Success → in-review
+        if: steps.validate.outputs.result == 'success'
+        uses: issue-ops/labeler@v4
+        with:
+          action: add
+          create: true
+          issue_number: ${{ github.event.issue.number }}
+          labels: |
+            registry-intake:in-review
+
+      - name: Success → comment with quorum hint
+        if: steps.validate.outputs.result == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment "${{ github.event.issue.number }}" -R "${{ github.repository }}" --body \
+          ":zap: Validation passed — this intake is now \`registry-intake:in-review\`.
+
+          **Pilots:** react with :+1: or :-1: on this issue. When you believe the quorum has been reached, comment \`.quorum-check\` to tally votes and either accept or reject.
+
+          The quorum policy for kind=\`${{ steps.kind.outputs.kind }}\` is in [\`.github/registry-quorum.yml\`](https://github.com/${{ github.repository }}/blob/main/.github/registry-quorum.yml)."
+
+      - name: Failure → validation-error label
+        if: steps.validate.outputs.result != 'success'
+        uses: issue-ops/labeler@v4
+        with:
+          action: add
+          create: true
+          issue_number: ${{ github.event.issue.number }}
+          labels: |
+            issueops:validation-error
+
+      - name: Failure → comment with rendered errors
+        if: steps.validate.outputs.result != 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_ERRORS: ${{ steps.validate.outputs.errors }}
+        run: |
+          python3 .github/scripts/render_validation_failure.py | \
+            gh issue comment "${{ github.event.issue.number }}" -R "${{ github.repository }}" --body-file -
+
+      - name: Failure → fail the job
+        if: steps.validate.outputs.result != 'success'
+        run: |
+          echo "::error::Form validation failed. See the issue comment for details."
+          exit 1


### PR DESCRIPTION
Add the validate-registry-intake workflow plus its supporting bits:

- issue-ops/parser + issue-ops/validator wiring against the kind-
  specific template (resolved from the issue's `registry-intake:<kind>`
  label).
- Custom JS validators for Stellar strkeys (G…/C…, 56 char base32),
  sha256 wasm hashes (64 hex), semver versions, contract/wasm names
  (kebab-case with optional `<prefix>/`), and https URLs.
- Python helper that pretty-prints the validator's error JSON into a
  friendly issue comment listing the offending fields.

On validation success the issue is labeled `registry-intake:in-review`
and a comment tells pilots how to vote. On failure the issue is
labeled `issueops:validation-error` and the rendered errors are
posted as a comment; the workflow re-runs whenever the issue is
edited.

Testable after merge: open an issue from any of the four templates,
once with valid fields (expect `:in-review` + hint comment) and once
with a malformed strkey/hash/semver (expect `issueops:validation-error`
+ rendered errors). No org PAT, no env, no signer secret needed yet.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>