### PR TITLE
feat: pilot quorum + on-chain submit workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/registry-admin.yml
+++ b/.github/ISSUE_TEMPLATE/registry-admin.yml
@@ -1,0 +1,111 @@
+name: "Registry: Admin op (manage / upgrade contract)"
+description: Request a sensitive op — change owner/address/name of a registered contract, or upgrade a deployed contract.
+title: "Registry Admin: "
+labels: ["registry-intake", "registry-intake:admin"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Registry Admin Intake (high-sensitivity)
+
+        Use this form for sensitive operations on already-registered or already-deployed
+        contracts. **Higher quorum applies** (see `.github/registry-quorum.yml`).
+
+        Only fill in the fields that apply to your chosen `method`. The validator will
+        reject submissions where required fields for that method are missing.
+
+        > **Out of scope for v1:** `set_admin`, `set_manager`, `remove_manager`, and
+        > registry-self `upgrade` all require **registry admin** auth, not the CI key.
+        > Those operations remain offline-only — see `docs/ci-publishing.md`.
+
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network
+      options:
+        - testnet
+        - mainnet
+    validations:
+      required: true
+
+  - type: dropdown
+    id: method
+    attributes:
+      label: Method
+      description: |
+        - `update_contract_owner` — change the owner of a registry entry.
+        - `update_contract_address` — point a registered name at a new contract address.
+        - `rename_contract` — rename a registry entry.
+        - `upgrade_contract` — upgrade a deployed contract to a different published wasm.
+      options:
+        - update_contract_owner
+        - update_contract_address
+        - rename_contract
+        - upgrade_contract
+    validations:
+      required: true
+
+  - type: input
+    id: contract_name
+    attributes:
+      label: Contract name (target)
+      description: The name of the registered contract being modified.
+      placeholder: e.g. hello, unverified/my-thing
+    validations:
+      required: true
+
+  - type: input
+    id: new_owner
+    attributes:
+      label: New owner (G… or C…) — `update_contract_owner` only
+      description: Required for `update_contract_owner`. Leave blank otherwise.
+      placeholder: G...56 or C...56
+    validations:
+      required: false
+
+  - type: input
+    id: new_address
+    attributes:
+      label: New contract address (C…) — `update_contract_address` only
+      description: Required for `update_contract_address`. Leave blank otherwise.
+      placeholder: C...56
+    validations:
+      required: false
+
+  - type: input
+    id: new_name
+    attributes:
+      label: New name — `rename_contract` only
+      description: Required for `rename_contract`. Use `unverified/<name>` for the unverified subregistry. Leave blank otherwise.
+      placeholder: e.g. hello-renamed
+    validations:
+      required: false
+
+  - type: input
+    id: wasm_name
+    attributes:
+      label: Wasm name — `upgrade_contract` only
+      description: Required for `upgrade_contract`. The published wasm name to upgrade to.
+      placeholder: e.g. hello, unverified/hello
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Wasm version — `upgrade_contract` only
+      description: Optional even for `upgrade_contract`. Leave blank to upgrade to the latest published version.
+      placeholder: e.g. 0.2.0
+    validations:
+      required: false
+
+  - type: textarea
+    id: justification
+    attributes:
+      label: Justification
+      description: |
+        High-sensitivity ops. Explain why this is needed, who has reviewed the change,
+        what testing has been done, and what the rollback plan is. Pilots use this to
+        decide whether to react 👍.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/registry-deploy.yml
+++ b/.github/ISSUE_TEMPLATE/registry-deploy.yml
@@ -1,0 +1,90 @@
+name: "Registry: Deploy contract"
+description: Request that a published wasm be deployed and registered under a name
+title: "Registry Deploy: "
+labels: ["registry-intake", "registry-intake:deploy"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Registry Deploy Intake
+
+        Use this form to request that a previously published wasm be deployed (instantiated)
+        and registered under a contract name on-chain.
+
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network
+      options:
+        - testnet
+        - mainnet
+    validations:
+      required: true
+
+  - type: input
+    id: wasm_name
+    attributes:
+      label: Wasm name
+      description: Name of the previously-published wasm to deploy.
+      placeholder: e.g. hello, unverified/hello
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Wasm version
+      description: Semver of the published wasm. Optional — leave blank to deploy the latest.
+      placeholder: e.g. 0.1.0
+    validations:
+      required: false
+
+  - type: input
+    id: contract_name
+    attributes:
+      label: Contract name
+      description: Name to register the deployed contract under. Use `unverified/<name>` for unverified subregistry.
+      placeholder: e.g. hello, unverified/my-hello
+    validations:
+      required: true
+
+  - type: input
+    id: admin
+    attributes:
+      label: Admin address (G… or C…)
+      description: Account or contract that will be set as admin of the deployed contract.
+      placeholder: G...56 or C...56
+    validations:
+      required: true
+
+  - type: textarea
+    id: constructor_args
+    attributes:
+      label: Constructor args (after `--`)
+      description: |
+        Extra args passed to the contract's `__constructor` after `--`. One `--name=value`
+        per line. Leave blank if the contract has no extra constructor parameters.
+      placeholder: |
+        --token=CTOKEN...
+        --fee_bps=30
+    validations:
+      required: false
+
+  - type: input
+    id: deployer
+    attributes:
+      label: Deployer address (G…)
+      description: Optional. Defaults to the registry contract itself.
+      placeholder: G...56
+    validations:
+      required: false
+
+  - type: textarea
+    id: justification
+    attributes:
+      label: Justification
+      description: |
+        Why should this wasm be deployed under this name? Has the wasm been reviewed?
+        Pilots use this to decide whether to react 👍.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/registry-publish.yml
+++ b/.github/ISSUE_TEMPLATE/registry-publish.yml
@@ -1,0 +1,100 @@
+name: "Registry: Publish wasm"
+description: Request a wasm hash (or full wasm) be published to the on-chain registry
+title: "Registry Publish: "
+labels: ["registry-intake", "registry-intake:publish"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Registry Publish Intake
+
+        Use this form to request that a wasm be recorded on the on-chain registry under a
+        name and version. Once a quorum of `registry-pilots` reacts 👍 and a pilot comments
+        `.quorum-check`, the on-chain submit workflow will run from a protected environment.
+
+        - For *trusted* names (no prefix), the registry's manager (CI key) will sign on behalf
+          of the author. For *unverified* names, prefix the wasm name with `unverified/`.
+        - Versions must be valid semver (`MAJOR.MINOR.PATCH`) and strictly greater than the
+          current on-chain version for the same name.
+
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network
+      description: Which network to publish to.
+      options:
+        - testnet
+        - mainnet
+    validations:
+      required: true
+
+  - type: dropdown
+    id: method
+    attributes:
+      label: Method
+      description: |
+        - `publish_hash` — record an already-uploaded wasm by its hash. Lower trust burden,
+          since the hash is supplied directly. **Recommended default.**
+        - `publish` — fetch the wasm from `wasm_url`, upload it, and record it. The workflow
+          will compute and verify the hash matches `wasm_hash`.
+      options:
+        - publish_hash
+        - publish
+    validations:
+      required: true
+
+  - type: input
+    id: wasm_name
+    attributes:
+      label: Wasm name
+      description: kebab-case. Use `unverified/<name>` to publish to the unverified subregistry.
+      placeholder: e.g. hello, unverified/hello, oz/fungible
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Semver. Must be strictly greater than the current on-chain version.
+      placeholder: e.g. 0.1.0
+    validations:
+      required: true
+
+  - type: input
+    id: wasm_hash
+    attributes:
+      label: Wasm hash (sha256, hex, 64 chars)
+      description: Required for `publish_hash`. For `publish`, optional — the workflow will compute and cross-check.
+      placeholder: 64-character hex string
+    validations:
+      required: false
+
+  - type: input
+    id: wasm_url
+    attributes:
+      label: Wasm release URL
+      description: Required for `publish` only. Direct URL to the optimized .wasm artifact (e.g. a GitHub release asset).
+      placeholder: https://github.com/owner/repo/releases/download/v0.1.0/contract.wasm
+    validations:
+      required: false
+
+  - type: input
+    id: author
+    attributes:
+      label: Author address (G…)
+      description: Stellar account address that will be recorded as the wasm's author. Optional — defaults to the CI signer if blank.
+      placeholder: G...56
+    validations:
+      required: false
+
+  - type: textarea
+    id: justification
+    attributes:
+      label: Justification
+      description: |
+        What is this wasm? What changed since the last published version? Who reviewed
+        the source offline (link reviews, audit reports, commit ranges)? Pilots use this
+        to decide whether to react 👍.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/registry-register.yml
+++ b/.github/ISSUE_TEMPLATE/registry-register.yml
@@ -1,0 +1,59 @@
+name: "Registry: Register existing contract"
+description: Request that an already-deployed contract be registered under a name in the registry
+title: "Registry Register: "
+labels: ["registry-intake", "registry-intake:register"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Registry Register-Contract Intake
+
+        Use this form to request that an existing on-chain contract be registered under
+        a name in the on-chain registry. The contract must already be deployed.
+
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network
+      options:
+        - testnet
+        - mainnet
+    validations:
+      required: true
+
+  - type: input
+    id: contract_name
+    attributes:
+      label: Contract name
+      description: kebab-case. Use `unverified/<name>` to register under the unverified subregistry.
+      placeholder: e.g. soroswap, unverified/my-thing
+    validations:
+      required: true
+
+  - type: input
+    id: contract_address
+    attributes:
+      label: Contract address (C…)
+      description: The on-chain address of the deployed contract being registered.
+      placeholder: C...56
+    validations:
+      required: true
+
+  - type: input
+    id: owner
+    attributes:
+      label: Owner address (G… or C…)
+      description: Account that will own this registry entry. Optional — defaults to the CI signer if blank.
+      placeholder: G...56 or C...56
+    validations:
+      required: false
+
+  - type: textarea
+    id: justification
+    attributes:
+      label: Justification
+      description: |
+        Why should this contract be registered under this name? Who controls the contract?
+        Has it been audited? Pilots use this to decide whether to react 👍.
+    validations:
+      required: true

--- a/.github/registry-quorum.yml
+++ b/.github/registry-quorum.yml
@@ -1,0 +1,34 @@
+# Per-kind quorum policy for the registry IssueOps pipeline.
+#
+# When a `registry-pilots` member comments `.quorum-check` on an in-review issue,
+# `registry-quorum-check.yml` reads this file and tallies pilot reactions against
+# the policy below. Mirrors the formula used by SCF's pg-atlas:
+#
+#     accepted iff ups >= (min_voters + 2 * downs)
+#
+# So for `min_voters: 3`: 3 ups beats 0 downs; 5 ups beats 1 down; 7 ups beats 2 downs.
+#
+# `require_unanimous: true` overrides the formula: any 👎 vote blocks acceptance,
+# regardless of 👍 count.
+#
+# Edits to this file go through normal PR review — keep the audit trail there.
+
+defaults:
+  team: registry-pilots          # GitHub team slug under the repo's org
+  min_voters: 3                  # minimum (ups + downs) before quorum can resolve
+  require_unanimous: false       # if true, any 👎 blocks acceptance
+
+# Per-kind overrides. The `kind` matches the `registry-intake:<kind>` label
+# applied by the issue form template.
+publish:
+  min_voters: 2
+
+register:
+  min_voters: 2
+
+deploy:
+  min_voters: 3
+
+admin:
+  min_voters: 3
+  require_unanimous: true        # high-sensitivity ops: any 👎 blocks

--- a/.github/scripts/parse_intake_to_args.py
+++ b/.github/scripts/parse_intake_to_args.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Translate a parsed registry-intake form into stellar-registry-cli args.
+
+Input via env vars:
+  KIND          — `publish` | `register` | `deploy` | `admin` (the form kind)
+  PARSED_JSON   — JSON emitted by `issue-ops/parser@v5` (the issue body fields)
+
+Outputs to $GITHUB_OUTPUT:
+  subcommand    — the stellar-registry-cli subcommand to invoke
+  args          — shlex-joined string of flags. Safe to `eval` after env-var passthrough.
+  network       — `testnet` | `mainnet` (echoed for the workflow's environment selector)
+  download_url  — optional. If set, the workflow must `curl -L -o $download_dest <url>`
+                  before invoking, and the args already reference $download_dest.
+  download_dest — optional. Path the workflow should download `download_url` to.
+
+This script is the single source of truth for kind→method→flag mapping. Edits here
+go through normal PR review.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import sys
+from typing import Any
+
+
+WASM_DOWNLOAD_DEST = "/tmp/registry-intake.wasm"
+
+
+def fail(msg: str) -> "Never":  # type: ignore[name-defined]
+    print(f"::error::{msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def emit(name: str, value: str) -> None:
+    out_path = os.environ.get("GITHUB_OUTPUT")
+    line = f"{name}={value}"
+    if out_path:
+        with open(out_path, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+    print(line)
+
+
+def get(form: dict[str, Any], key: str, *, required: bool = False) -> str:
+    value = (form.get(key) or "").strip() if isinstance(form.get(key), str) else ""
+    if required and not value:
+        fail(f"missing required form field `{key}`")
+    return value
+
+
+def build_publish(form: dict[str, Any]) -> tuple[str, list[str], str | None, str | None]:
+    method = get(form, "method", required=True)
+    wasm_name = get(form, "wasm_name", required=True)
+    version = get(form, "version", required=True)
+    wasm_hash = get(form, "wasm_hash")
+    wasm_url = get(form, "wasm_url")
+    author = get(form, "author")
+
+    if method == "publish_hash":
+        if not wasm_hash:
+            fail("`publish_hash` requires `wasm_hash`")
+        args = [
+            "--wasm-hash", wasm_hash,
+            "--wasm-name", wasm_name,
+            "--version", version,
+        ]
+        if author:
+            args += ["--author", author]
+        return "publish-hash", args, None, None
+
+    if method == "publish":
+        if not wasm_url:
+            fail("`publish` requires `wasm_url` so the workflow can fetch the wasm bytes")
+        args = [
+            "--wasm", WASM_DOWNLOAD_DEST,
+            "--wasm-name", wasm_name,
+            "--binver", version,
+        ]
+        if author:
+            args += ["--author", author]
+        return "publish", args, wasm_url, WASM_DOWNLOAD_DEST
+
+    fail(f"unknown publish method `{method}` (expected `publish_hash` or `publish`)")
+
+
+def build_register(form: dict[str, Any]) -> tuple[str, list[str], None, None]:
+    contract_name = get(form, "contract_name", required=True)
+    contract_address = get(form, "contract_address", required=True)
+    owner = get(form, "owner")
+
+    args = [
+        "--contract-name", contract_name,
+        "--contract-address", contract_address,
+    ]
+    if owner:
+        args += ["--owner", owner]
+    return "register-contract", args, None, None
+
+
+def build_deploy(form: dict[str, Any]) -> tuple[str, list[str], None, None]:
+    wasm_name = get(form, "wasm_name", required=True)
+    contract_name = get(form, "contract_name", required=True)
+    admin = get(form, "admin", required=True)
+    version = get(form, "version")
+    deployer = get(form, "deployer")
+    constructor_args = (form.get("constructor_args") or "").strip()
+
+    args = [
+        "--wasm-name", wasm_name,
+        "--contract-name", contract_name,
+    ]
+    if version:
+        args += ["--version", version]
+    if deployer:
+        args += ["--deployer", deployer]
+
+    args.append("--")
+    args.append(f"--admin={admin}")
+    # Each non-blank line of constructor_args is treated as one extra `--key=value`
+    # arg passed to `__constructor`. Submitters write them one per line.
+    for line in constructor_args.splitlines():
+        line = line.strip()
+        if line:
+            args.append(line)
+
+    return "deploy", args, None, None
+
+
+def build_admin(form: dict[str, Any]) -> tuple[str, list[str], None, None]:
+    method = get(form, "method", required=True)
+    contract_name = get(form, "contract_name", required=True)
+
+    if method == "update_contract_owner":
+        new_owner = get(form, "new_owner", required=True)
+        return "update-contract-owner", [
+            "--contract-name", contract_name,
+            "--new-owner", new_owner,
+        ], None, None
+
+    if method == "update_contract_address":
+        new_address = get(form, "new_address", required=True)
+        return "update-contract-address", [
+            "--contract-name", contract_name,
+            "--new-address", new_address,
+        ], None, None
+
+    if method == "rename_contract":
+        new_name = get(form, "new_name", required=True)
+        return "rename-contract", [
+            "--contract-name", contract_name,
+            "--new-name", new_name,
+        ], None, None
+
+    if method == "upgrade_contract":
+        wasm_name = get(form, "wasm_name", required=True)
+        version = get(form, "version")
+        args = [
+            "--contract-name", contract_name,
+            "--wasm-name", wasm_name,
+        ]
+        if version:
+            args += ["--version", version]
+        return "upgrade", args, None, None
+
+    fail(f"unknown admin method `{method}`")
+
+
+def main() -> int:
+    kind = (os.environ.get("KIND") or "").strip()
+    raw = (os.environ.get("PARSED_JSON") or "").strip()
+    if not kind:
+        fail("KIND env var is required")
+    if not raw:
+        fail("PARSED_JSON env var is required")
+
+    try:
+        form = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        fail(f"PARSED_JSON is not valid JSON: {exc}")
+
+    if not isinstance(form, dict):
+        fail("PARSED_JSON must decode to an object")
+
+    network = get(form, "network", required=True)
+    if network not in {"testnet", "mainnet"}:
+        fail(f"network must be `testnet` or `mainnet`, got `{network}`")
+
+    builders = {
+        "publish": build_publish,
+        "register": build_register,
+        "deploy": build_deploy,
+        "admin": build_admin,
+    }
+    if kind not in builders:
+        fail(f"unknown kind `{kind}` (expected one of {sorted(builders)})")
+
+    subcommand, args, download_url, download_dest = builders[kind](form)
+
+    emit("subcommand", subcommand)
+    emit("args", shlex.join(args))
+    emit("network", network)
+    emit("download_url", download_url or "")
+    emit("download_dest", download_dest or "")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/render_validation_failure.py
+++ b/.github/scripts/render_validation_failure.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Render issue-ops/validator's `errors` JSON output into a friendly markdown comment.
+
+Reads `COMMENT_ERRORS` from the environment (a JSON string emitted by
+`issue-ops/validator@v4`'s `errors` output) and prints a markdown body to stdout.
+The caller pipes that into `gh issue comment --body-file -`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def main() -> int:
+    raw = os.environ.get("COMMENT_ERRORS", "").strip()
+    if not raw:
+        print(":x: Validation failed but no error details were emitted by the validator.")
+        return 0
+
+    try:
+        errors = json.loads(raw)
+    except json.JSONDecodeError:
+        print(":x: Validation failed. Raw validator output:\n\n```\n" + raw + "\n```")
+        return 0
+
+    if not isinstance(errors, list) or not errors:
+        print(":x: Validation failed but the error list was empty or malformed.")
+        return 0
+
+    lines = [
+        ":x: **Validation failed.** Please edit the issue to fix the problems below — the form will be re-validated automatically.",
+        "",
+    ]
+    for err in errors:
+        if isinstance(err, dict):
+            field = err.get("field") or err.get("name") or "(field)"
+            msg = err.get("message") or err.get("error") or json.dumps(err)
+            lines.append(f"- **`{field}`** — {msg}")
+        else:
+            lines.append(f"- {err}")
+    lines.append("")
+    lines.append(
+        "Once you've edited the fields, the `issueops:validation-error` label will be removed and the issue will move to `registry-intake:in-review`."
+    )
+
+    print("\n".join(lines))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/validator/config.yml
+++ b/.github/validator/config.yml
@@ -1,0 +1,42 @@
+# issue-ops/validator@v4 config. Each entry maps an issue-form field id to a
+# validator script under this directory. Empty values pass — required-ness is
+# enforced by the form template's `validations: required: true`.
+#
+# All four registry intake forms share this config. Fields that don't exist on
+# a particular form are skipped automatically.
+validators:
+  # Wasm/contract names (kebab-case with optional `prefix/`).
+  - field: wasm_name
+    script: validate-contract-name.js
+  - field: contract_name
+    script: validate-contract-name.js
+  - field: new_name
+    script: validate-contract-name.js
+
+  # Stellar strkey addresses — accepts G… (account) or C… (contract).
+  - field: author
+    script: validate-stellar-strkey.js
+  - field: contract_address
+    script: validate-stellar-strkey.js
+  - field: owner
+    script: validate-stellar-strkey.js
+  - field: admin
+    script: validate-stellar-strkey.js
+  - field: deployer
+    script: validate-stellar-strkey.js
+  - field: new_owner
+    script: validate-stellar-strkey.js
+  - field: new_address
+    script: validate-stellar-strkey.js
+
+  # Wasm hash — sha256 hex, 64 chars.
+  - field: wasm_hash
+    script: validate-wasm-hash.js
+
+  # Semver MAJOR.MINOR.PATCH (with optional pre-release/build metadata).
+  - field: version
+    script: validate-semver.js
+
+  # Wasm release URL — https only.
+  - field: wasm_url
+    script: validate-https-url.js

--- a/.github/validator/validate-contract-name.js
+++ b/.github/validator/validate-contract-name.js
@@ -1,0 +1,16 @@
+module.exports = async (field) => {
+  if (!field || typeof field !== 'string') return 'success';
+  const value = field.trim();
+  if (value.length === 0) return 'success';
+  // Optional `<prefix>/` then a kebab-or-snake segment. Each segment must
+  // start with a lowercase letter and contain only [a-z0-9_-]. Length capped
+  // at 64 chars total to match the registry's name storage policy.
+  const re = /^([a-z][a-z0-9_-]*\/)?[a-z][a-z0-9_-]*$/;
+  if (!re.test(value)) {
+    return 'name must be kebab- or snake-case (lowercase letters, digits, `_`, `-`), optionally prefixed with `<subregistry>/`. Examples: `hello`, `unverified/my-thing`, `oz/fungible_token`.';
+  }
+  if (value.length > 64) {
+    return `name exceeds 64 characters (current: ${value.length}).`;
+  }
+  return 'success';
+};

--- a/.github/validator/validate-https-url.js
+++ b/.github/validator/validate-https-url.js
@@ -1,0 +1,10 @@
+module.exports = async (field) => {
+  if (!field || typeof field !== 'string') return 'success';
+  const value = field.trim();
+  if (value.length === 0) return 'success';
+  const re = /^https:\/\/[^\s/$.?#].[^\s]*$/i;
+  if (!re.test(value)) {
+    return 'URL must start with `https://` and be a well-formed URL.';
+  }
+  return 'success';
+};

--- a/.github/validator/validate-semver.js
+++ b/.github/validator/validate-semver.js
@@ -1,0 +1,14 @@
+module.exports = async (field) => {
+  if (!field || typeof field !== 'string') return 'success';
+  const value = field.trim();
+  if (value.length === 0) return 'success';
+  // Semver per https://semver.org with optional pre-release and build metadata.
+  // The registry stores versions as opaque strings but enforces strict ordering
+  // on publish, so an invalid semver here will be rejected later — better to
+  // catch it at the form stage.
+  const re = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+  if (!re.test(value)) {
+    return 'version must be valid semver (`MAJOR.MINOR.PATCH`, optionally with pre-release and build metadata). Examples: `0.1.0`, `1.2.3-rc.1`, `2.0.0+build.5`.';
+  }
+  return 'success';
+};

--- a/.github/validator/validate-stellar-strkey.js
+++ b/.github/validator/validate-stellar-strkey.js
@@ -1,0 +1,14 @@
+module.exports = async (field) => {
+  if (!field || typeof field !== 'string') return 'success';
+  const value = field.trim();
+  if (value.length === 0) return 'success';
+  // Stellar strkey: 56 chars, base32 alphabet (A-Z, 2-7), version byte
+  // determines kind. We accept G (ed25519 account) or C (contract).
+  // Muxed M and signed-payload P are intentionally rejected for these fields —
+  // the registry methods take account/contract addresses, not muxed.
+  const re = /^[GC][A-Z2-7]{55}$/;
+  if (!re.test(value)) {
+    return 'must be a 56-character Stellar strkey starting with `G` (account) or `C` (contract). Example: `GABC…56-chars` or `CABC…56-chars`.';
+  }
+  return 'success';
+};

--- a/.github/validator/validate-wasm-hash.js
+++ b/.github/validator/validate-wasm-hash.js
@@ -1,0 +1,12 @@
+module.exports = async (field) => {
+  if (!field || typeof field !== 'string') return 'success';
+  const value = field.trim();
+  if (value.length === 0) return 'success';
+  // sha256 — 32 bytes, hex-encoded → 64 lowercase hex chars (case-insensitive
+  // accepted; the on-chain registry stores it as bytes regardless).
+  const re = /^[0-9a-fA-F]{64}$/;
+  if (!re.test(value)) {
+    return `wasm hash must be a 64-character hex sha256 (current length: ${value.length}). No \`0x\` prefix. Example: \`a1b2…64-chars\`.`;
+  }
+  return 'success';
+};

--- a/.github/workflows/registry-onchain-submit.yml
+++ b/.github/workflows/registry-onchain-submit.yml
@@ -1,0 +1,227 @@
+name: Registry On-Chain Submit
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: GitHub issue number that triggered this submit
+        required: true
+        type: string
+      kind:
+        description: Form kind (publish, register, deploy, admin)
+        required: true
+        type: choice
+        options: [publish, register, deploy, admin]
+      network:
+        description: Stellar network to submit on
+        required: true
+        type: choice
+        options: [testnet, mainnet]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      template: ${{ steps.t.outputs.template }}
+      issue_body: ${{ steps.fetch.outputs.body }}
+    steps:
+      - name: Verify issue is `registry-intake:accepted`
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ inputs.issue_number }}
+        run: |
+          set -euo pipefail
+          LABELS=$(gh issue view "$ISSUE" -R "${{ github.repository }}" --json labels --jq '[.labels[].name]')
+          echo "Labels on #$ISSUE: $LABELS"
+          if ! jq -e 'index("registry-intake:accepted")' <<<"$LABELS" >/dev/null; then
+            echo "::error::Issue #$ISSUE does not carry the \`registry-intake:accepted\` label. Aborting — only quorum-approved intakes can be submitted on-chain."
+            exit 1
+          fi
+          if ! jq -e --arg kind "registry-intake:${{ inputs.kind }}" 'index($kind)' <<<"$LABELS" >/dev/null; then
+            echo "::error::Issue #$ISSUE does not carry the \`registry-intake:${{ inputs.kind }}\` kind label. Dispatched kind does not match the issue's kind."
+            exit 1
+          fi
+
+      - name: Map kind → template
+        id: t
+        run: |
+          case "${{ inputs.kind }}" in
+            publish)  TEMPLATE=registry-publish.yml ;;
+            register) TEMPLATE=registry-register.yml ;;
+            deploy)   TEMPLATE=registry-deploy.yml ;;
+            admin)    TEMPLATE=registry-admin.yml ;;
+          esac
+          echo "template=$TEMPLATE" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch issue body
+        id: fetch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ inputs.issue_number }}
+        run: |
+          set -euo pipefail
+          BODY=$(gh issue view "$ISSUE" -R "${{ github.repository }}" --json body --jq '.body')
+          # Encode as base64 to safely round-trip through GITHUB_OUTPUT.
+          B64=$(printf '%s' "$BODY" | base64 -w 0)
+          echo "body=$B64" >> "$GITHUB_OUTPUT"
+
+  submit:
+    needs: preflight
+    runs-on: ubuntu-latest
+    environment: registry-${{ inputs.network }}
+    env:
+      STELLAR_NETWORK_PASSPHRASE: ${{ secrets.STELLAR_NETWORK_PASSPHRASE }}
+      STELLAR_RPC_URL:           ${{ vars.STELLAR_RPC_URL }}
+      STELLAR_REGISTRY_CONTRACT_ID: ${{ vars.STELLAR_REGISTRY_CONTRACT_ID }}
+      STELLAR_SOURCE_SECRET:     ${{ secrets.STELLAR_SECRET_KEY }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Decode issue body
+        id: body
+        env:
+          B64: ${{ needs.preflight.outputs.issue_body }}
+        run: |
+          echo "$B64" | base64 -d > /tmp/issue_body.md
+          ls -la /tmp/issue_body.md
+
+      - name: Parse issue body
+        id: parse
+        uses: issue-ops/parser@v5
+        with:
+          body-file: /tmp/issue_body.md
+          issue-form-template: ${{ needs.preflight.outputs.template }}
+
+      - name: Re-validate (defense in depth)
+        id: validate
+        uses: issue-ops/validator@v4
+        with:
+          issue-form-template: ${{ needs.preflight.outputs.template }}
+          parsed-issue-body: ${{ steps.parse.outputs.json }}
+          add-comment: false
+
+      - name: Fail if revalidation regressed
+        if: steps.validate.outputs.result != 'success'
+        run: |
+          echo "::error::Issue body re-validation failed at submit time. The issue may have been edited between approval and dispatch."
+          exit 1
+
+      - name: Build CLI args
+        id: args
+        env:
+          KIND:        ${{ inputs.kind }}
+          PARSED_JSON: ${{ steps.parse.outputs.json }}
+        run: python3 .github/scripts/parse_intake_to_args.py
+
+      - name: Install Stellar CLI
+        uses: stellar/stellar-cli@v26.0.0
+        with:
+          version: "26.0.0"
+
+      - name: Configure Stellar CLI signer
+        run: |
+          set -euo pipefail
+          export XDG_CONFIG_HOME="${RUNNER_TEMP}/xdg-config"
+          mkdir -p "$XDG_CONFIG_HOME"
+          echo "XDG_CONFIG_HOME=$XDG_CONFIG_HOME" >> "$GITHUB_ENV"
+          stellar network add \
+            --rpc-url "$STELLAR_RPC_URL" \
+            --network-passphrase "$STELLAR_NETWORK_PASSPHRASE" \
+            "${{ inputs.network }}"
+          printf '%s\n' "$STELLAR_SOURCE_SECRET" | stellar keys add ci
+
+      - name: Download wasm (if publish from URL)
+        if: steps.args.outputs.download_url != ''
+        env:
+          URL:  ${{ steps.args.outputs.download_url }}
+          DEST: ${{ steps.args.outputs.download_dest }}
+        run: |
+          set -euo pipefail
+          curl -fsSL --max-time 60 -o "$DEST" "$URL"
+          ls -la "$DEST"
+
+      - name: Set up Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Invoke registry method
+        id: tx
+        env:
+          SUBCMD:  ${{ steps.args.outputs.subcommand }}
+          ARGS:    ${{ steps.args.outputs.args }}
+          NETWORK: ${{ inputs.network }}
+        run: |
+          set -euo pipefail
+          # ARGS comes from shlex.join, so eval is safe under env-var passthrough.
+          # We capture stderr+stdout into a log and grep the tx hash. The CLI
+          # prints "Successfully …" on success and the underlying invoke logs
+          # the hash before that.
+          LOG=$(mktemp)
+          set +e
+          eval "cargo run --release -p stellar-registry-cli -- $SUBCMD --source ci --network $NETWORK $ARGS" > >(tee "$LOG") 2> >(tee -a "$LOG" >&2)
+          STATUS=$?
+          set -e
+          if [ "$STATUS" -ne 0 ]; then
+            echo "::error::stellar-registry-cli exited with status $STATUS"
+            tail -200 "$LOG"
+            exit "$STATUS"
+          fi
+          # stellar-cli logs lines like `Signing transaction: …` and `Transaction hash is …`.
+          TX_HASH=$(grep -oE '[0-9a-f]{64}' "$LOG" | tail -n 1 || true)
+          echo "hash=${TX_HASH:-unknown}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment success on issue
+        if: success()
+        env:
+          ISSUE: ${{ inputs.issue_number }}
+          HASH:  ${{ steps.tx.outputs.hash }}
+          NET:   ${{ inputs.network }}
+        run: |
+          gh issue comment "$ISSUE" -R "${{ github.repository }}" --body \
+            ":zap: **Submitted on-chain.**
+
+            | | |
+            | --- | --- |
+            | **Kind** | \`${{ inputs.kind }}\` |
+            | **Network** | \`$NET\` |
+            | **Tx hash** | \`$HASH\` |
+            | **Signer** | the CI key (registry manager) |
+            | **Run** | https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} |"
+
+      - name: Mark submitted
+        if: success()
+        uses: issue-ops/labeler@v4
+        with:
+          action: add
+          create: true
+          issue_number: ${{ inputs.issue_number }}
+          labels: |
+            registry-intake:submitted
+
+      - name: Close issue on success
+        if: success()
+        env:
+          ISSUE: ${{ inputs.issue_number }}
+        run: gh issue close "$ISSUE" -R "${{ github.repository }}" --reason completed
+
+      - name: Comment failure on issue
+        if: failure()
+        env:
+          ISSUE: ${{ inputs.issue_number }}
+        run: |
+          gh issue comment "$ISSUE" -R "${{ github.repository }}" --body \
+            ":x: **On-chain submit failed.** See the [run logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details. The issue has been labeled \`registry-intake:submission-failed\`. A maintainer can re-trigger the submit via the workflow_dispatch UI once the underlying issue is fixed."
+
+      - name: Mark submission-failed
+        if: failure()
+        uses: issue-ops/labeler@v4
+        with:
+          action: add
+          create: true
+          issue_number: ${{ inputs.issue_number }}
+          labels: |
+            registry-intake:submission-failed

--- a/.github/workflows/registry-quorum-check.yml
+++ b/.github/workflows/registry-quorum-check.yml
@@ -1,0 +1,269 @@
+name: Registry Intake - Quorum Check
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  contents: read
+  actions: write   # required to dispatch registry-onchain-submit.yml on accept
+
+jobs:
+  quorum-check:
+    # Run only on comments for non-PR issues that are currently in-review.
+    if: |
+      github.event.issue.pull_request == null &&
+      contains(github.event.issue.labels.*.name, 'registry-intake:in-review')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Look for .quorum-check command
+        id: command
+        uses: github/command@v2
+        with:
+          command: .quorum-check
+          status: ${{ job.status }}
+          allowed_contexts: issue
+          permissions: write,admin
+          # Allowlist resolved by the action via the org-scoped PAT below.
+          # The team slug is read from .github/registry-quorum.yml at the
+          # script step — keep this allowlist in sync with that file.
+          allowlist: ${{ github.repository_owner }}/registry-pilots
+          allowlist_pat: ${{ secrets.READ_ORG_MEMBERS_PAT }}
+          skip_ci: "true"
+          skip_reviews: "true"
+          reaction: eyes
+          skip_completing: "true"
+
+      - name: Checkout repo (for policy file)
+        if: steps.command.outputs.continue == 'true'
+        uses: actions/checkout@v6
+
+      - name: Resolve kind subtype label
+        if: steps.command.outputs.continue == 'true'
+        id: kind
+        env:
+          LABELS_JSON: ${{ toJSON(github.event.issue.labels) }}
+        run: |
+          set -euo pipefail
+          KIND=$(jq -r '
+            .[].name
+            | select(startswith("registry-intake:"))
+            | sub("^registry-intake:"; "")
+            | select(. == "publish" or . == "register" or . == "deploy" or . == "admin")
+          ' <<<"$LABELS_JSON" | head -n 1)
+          if [ -z "${KIND:-}" ]; then
+            echo "::error::No kind subtype label on issue."
+            exit 1
+          fi
+          echo "kind=$KIND" >> "$GITHUB_OUTPUT"
+
+      - name: Load quorum policy for kind
+        if: steps.command.outputs.continue == 'true'
+        id: policy
+        env:
+          KIND: ${{ steps.kind.outputs.kind }}
+        run: |
+          set -euo pipefail
+          POLICY_FILE=.github/registry-quorum.yml
+          # yq is preinstalled on ubuntu-latest runners.
+          TEAM=$(yq -r ".defaults.team" "$POLICY_FILE")
+          MIN_VOTERS=$(yq -r ".\"$KIND\".min_voters // .defaults.min_voters" "$POLICY_FILE")
+          REQUIRE_UNANIMOUS=$(yq -r ".\"$KIND\".require_unanimous // .defaults.require_unanimous // false" "$POLICY_FILE")
+          echo "team=$TEAM" >> "$GITHUB_OUTPUT"
+          echo "min_voters=$MIN_VOTERS" >> "$GITHUB_OUTPUT"
+          echo "require_unanimous=$REQUIRE_UNANIMOUS" >> "$GITHUB_OUTPUT"
+
+      - name: Tally pilot reactions and decide
+        if: steps.command.outputs.continue == 'true'
+        id: decide
+        uses: actions/github-script@v8
+        env:
+          READ_ORG_MEMBERS_PAT: ${{ secrets.READ_ORG_MEMBERS_PAT }}
+          PILOT_TEAM_SLUG: ${{ steps.policy.outputs.team }}
+          MIN_VOTERS: ${{ steps.policy.outputs.min_voters }}
+          REQUIRE_UNANIMOUS: ${{ steps.policy.outputs.require_unanimous }}
+          KIND: ${{ steps.kind.outputs.kind }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pat = process.env.READ_ORG_MEMBERS_PAT;
+            if (!pat) {
+              core.setFailed('READ_ORG_MEMBERS_PAT secret is not configured');
+              return;
+            }
+            const PILOT_TEAM_SLUG    = process.env.PILOT_TEAM_SLUG;
+            const MIN_VOTERS         = parseInt(process.env.MIN_VOTERS, 10);
+            const REQUIRE_UNANIMOUS  = process.env.REQUIRE_UNANIMOUS === 'true';
+            const KIND               = process.env.KIND;
+
+            const { owner, repo } = context.repo;
+            const issueNumber     = context.issue.number;
+            const GH_API_VERSION  = '2026-03-10';
+
+            async function ghFetch(url) {
+              const res = await fetch(url, {
+                headers: {
+                  Authorization: `Bearer ${pat}`,
+                  Accept: 'application/vnd.github+json',
+                  'X-GitHub-Api-Version': GH_API_VERSION,
+                },
+              });
+              if (!res.ok) throw new Error(`GitHub API error ${res.status} for ${url}`);
+              return res;
+            }
+
+            async function loadPilotMembers() {
+              const members = new Set();
+              let url = `https://api.github.com/orgs/${owner}/teams/${PILOT_TEAM_SLUG}/members?per_page=100`;
+              while (url) {
+                const res  = await ghFetch(url);
+                const page = await res.json();
+                for (const m of page) members.add(m.login);
+                const link = res.headers.get('link') ?? '';
+                const next = link.match(/<([^>]+)>;\s*rel="next"/);
+                url = next ? next[1] : null;
+              }
+              return members;
+            }
+
+            async function loadReactions() {
+              return github.paginate(
+                github.rest.reactions.listForIssue,
+                { owner, repo, issue_number: issueNumber, per_page: 100 }
+              );
+            }
+
+            const [pilotMembers, allReactions] = await Promise.all([
+              loadPilotMembers(),
+              loadReactions(),
+            ]);
+
+            const upSet   = new Set();
+            const downSet = new Set();
+            for (const r of allReactions) {
+              const login = r.user?.login;
+              if (!login || !pilotMembers.has(login)) continue;
+              if (r.content === '+1')      upSet.add(login);
+              else if (r.content === '-1') downSet.add(login);
+            }
+
+            const pilotUps   = [...upSet];
+            const pilotDowns = [...downSet];
+            const ups        = pilotUps.length;
+            const downs      = pilotDowns.length;
+            const total      = ups + downs;
+
+            if (total < MIN_VOTERS) {
+              const needed = MIN_VOTERS - total;
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issueNumber,
+                body: `:hourglass: Not enough pilot votes to finalize yet — ${total} of ${MIN_VOTERS} minimum cast (${needed} more needed) for kind \`${KIND}\`.`,
+              });
+              core.setOutput('decided', 'false');
+              return;
+            }
+
+            let accepted;
+            if (REQUIRE_UNANIMOUS) {
+              accepted = downs === 0 && ups >= MIN_VOTERS;
+            } else {
+              const threshold = MIN_VOTERS + 2 * downs;
+              accepted = ups >= threshold;
+            }
+
+            const upList   = pilotUps.map(l   => `@${l}`).join(', ') || '_none_';
+            const downList = pilotDowns.map(l => `@${l}`).join(', ') || '_none_';
+            const policy   = REQUIRE_UNANIMOUS
+              ? `unanimous (any :-1: blocks), min ${MIN_VOTERS} :+1:`
+              : `${MIN_VOTERS} + 2*downs threshold`;
+
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.createLabel({ owner, repo, name, color, description });
+              } catch (e) { if (e.status !== 422) throw e; }
+            }
+            await Promise.all([
+              ensureLabel('registry-intake:accepted', '0e8a16', 'Pilot quorum accepted this intake'),
+              ensureLabel('registry-intake:rejected', 'd93f0b', 'Pilot quorum rejected this intake'),
+            ]);
+
+            // Move from in-review → accepted/rejected.
+            try {
+              await github.rest.issues.removeLabel({
+                owner, repo, issue_number: issueNumber, name: 'registry-intake:in-review',
+              });
+            } catch (_) {}
+            await github.rest.issues.addLabels({
+              owner, repo, issue_number: issueNumber,
+              labels: [accepted ? 'registry-intake:accepted' : 'registry-intake:rejected'],
+            });
+
+            const icon    = accepted ? ':zap:' : ':card_file_box:';
+            const verdict = accepted ? '**Accepted**' : '**Rejected**';
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: issueNumber,
+              body: [
+                `${icon} ${verdict} for kind \`${KIND}\` — ${ups} :+1:, ${downs} :-1: (policy: ${policy})`,
+                ``,
+                `:+1: ${upList}`,
+                `:-1: ${downList}`,
+              ].join('\n'),
+            });
+
+            core.setOutput('decided',  'true');
+            core.setOutput('accepted', String(accepted));
+
+      - name: Reject path → close and lock
+        if: steps.command.outputs.continue == 'true' && steps.decide.outputs.decided == 'true' && steps.decide.outputs.accepted == 'false'
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const issueNumber     = context.issue.number;
+            await github.rest.issues.update({
+              owner, repo, issue_number: issueNumber,
+              state: 'closed', state_reason: 'completed',
+            });
+            await github.rest.issues.lock({
+              owner, repo, issue_number: issueNumber, lock_reason: 'resolved',
+            });
+
+      - name: Read network from issue body (for environment selection)
+        if: steps.command.outputs.continue == 'true' && steps.decide.outputs.accepted == 'true'
+        id: network
+        env:
+          BODY: ${{ github.event.issue.body }}
+        run: |
+          set -euo pipefail
+          # Issue forms render as markdown headers + values. Pick the line under the
+          # `### Network` heading.
+          NETWORK=$(awk '
+            BEGIN { found = 0 }
+            /^### Network$/ { found = 1; next }
+            found && NF { print; exit }
+          ' <<<"$BODY" | tr -d ' \r\n')
+          if [ "$NETWORK" != "testnet" ] && [ "$NETWORK" != "mainnet" ]; then
+            echo "::error::Could not parse network from issue body (got: '$NETWORK')"
+            exit 1
+          fi
+          echo "network=$NETWORK" >> "$GITHUB_OUTPUT"
+
+      - name: Accept path → dispatch on-chain submit
+        if: steps.command.outputs.continue == 'true' && steps.decide.outputs.accepted == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          KIND:    ${{ steps.kind.outputs.kind }}
+          NETWORK: ${{ steps.network.outputs.network }}
+        run: |
+          set -euo pipefail
+          gh workflow run registry-onchain-submit.yml \
+            -R "${{ github.repository }}" \
+            --ref "${{ github.event.repository.default_branch }}" \
+            --field "issue_number=${ISSUE_NUMBER}" \
+            --field "kind=${KIND}" \
+            --field "network=${NETWORK}"
+          gh issue comment "${ISSUE_NUMBER}" -R "${{ github.repository }}" --body \
+            ":hourglass_flowing_sand: Dispatched [\`registry-onchain-submit\`](https://github.com/${{ github.repository }}/actions/workflows/registry-onchain-submit.yml) for kind=\`${KIND}\` on \`${NETWORK}\`. The workflow will pause at the \`registry-${NETWORK}\` environment for reviewer approval before signing."

--- a/.github/workflows/validate-registry-intake.yml
+++ b/.github/workflows/validate-registry-intake.yml
@@ -1,0 +1,120 @@
+name: Validate Registry Intake
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  validate:
+    if: contains(github.event.issue.labels.*.name, 'registry-intake')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clear previous state labels
+        # Kind subtype labels (registry-intake:publish/register/deploy/admin) are
+        # applied by the form template itself and are NOT cleared here — they
+        # persist for the lifetime of the issue.
+        uses: issue-ops/labeler@v4
+        with:
+          action: remove
+          issue_number: ${{ github.event.issue.number }}
+          labels: |
+            registry-intake:in-review
+            registry-intake:accepted
+            registry-intake:rejected
+            registry-intake:submitted
+            registry-intake:submission-failed
+            issueops:validation-error
+
+      - name: Resolve form kind and template
+        id: kind
+        env:
+          LABELS_JSON: ${{ toJSON(github.event.issue.labels) }}
+        run: |
+          set -euo pipefail
+          KIND=$(jq -r '
+            .[].name
+            | select(startswith("registry-intake:"))
+            | sub("^registry-intake:"; "")
+            | select(. == "publish" or . == "register" or . == "deploy" or . == "admin")
+          ' <<<"$LABELS_JSON" | head -n 1)
+          if [ -z "${KIND:-}" ]; then
+            echo "::error::Issue has the parent `registry-intake` label but no kind subtype (publish/register/deploy/admin). The form template should set both."
+            exit 1
+          fi
+          case "$KIND" in
+            publish)  TEMPLATE=registry-publish.yml ;;
+            register) TEMPLATE=registry-register.yml ;;
+            deploy)   TEMPLATE=registry-deploy.yml ;;
+            admin)    TEMPLATE=registry-admin.yml ;;
+          esac
+          echo "kind=$KIND" >> "$GITHUB_OUTPUT"
+          echo "template=$TEMPLATE" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repo (for validator scripts and form templates)
+        uses: actions/checkout@v6
+
+      - name: Parse intake form
+        id: parse
+        uses: issue-ops/parser@v5
+        with:
+          body: ${{ github.event.issue.body }}
+          issue-form-template: ${{ steps.kind.outputs.template }}
+
+      - name: Validate intake form
+        id: validate
+        uses: issue-ops/validator@v4
+        with:
+          issue-form-template: ${{ steps.kind.outputs.template }}
+          parsed-issue-body: ${{ steps.parse.outputs.json }}
+          add-comment: false
+
+      - name: Success → in-review
+        if: steps.validate.outputs.result == 'success'
+        uses: issue-ops/labeler@v4
+        with:
+          action: add
+          create: true
+          issue_number: ${{ github.event.issue.number }}
+          labels: |
+            registry-intake:in-review
+
+      - name: Success → comment with quorum hint
+        if: steps.validate.outputs.result == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment "${{ github.event.issue.number }}" -R "${{ github.repository }}" --body \
+          ":zap: Validation passed — this intake is now \`registry-intake:in-review\`.
+
+          **Pilots:** react with :+1: or :-1: on this issue. When you believe the quorum has been reached, comment \`.quorum-check\` to tally votes and either accept or reject.
+
+          The quorum policy for kind=\`${{ steps.kind.outputs.kind }}\` is in [\`.github/registry-quorum.yml\`](https://github.com/${{ github.repository }}/blob/main/.github/registry-quorum.yml)."
+
+      - name: Failure → validation-error label
+        if: steps.validate.outputs.result != 'success'
+        uses: issue-ops/labeler@v4
+        with:
+          action: add
+          create: true
+          issue_number: ${{ github.event.issue.number }}
+          labels: |
+            issueops:validation-error
+
+      - name: Failure → comment with rendered errors
+        if: steps.validate.outputs.result != 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_ERRORS: ${{ steps.validate.outputs.errors }}
+        run: |
+          python3 .github/scripts/render_validation_failure.py | \
+            gh issue comment "${{ github.event.issue.number }}" -R "${{ github.repository }}" --body-file -
+
+      - name: Failure → fail the job
+        if: steps.validate.outputs.result != 'success'
+        run: |
+          echo "::error::Form validation failed. See the issue comment for details."
+          exit 1


### PR DESCRIPTION
Add the two workflows that close the loop from in-review issue to
on-chain registry transaction, plus the per-kind quorum policy and
the CLI-args parser:

- .github/registry-quorum.yml: per-kind `min_voters` and
  `require_unanimous` (admin kind requires unanimous; any 👎 blocks).
  Default formula mirrors SCF pg-atlas: `ups ≥ min_voters + 2*downs`.
- registry-quorum-check.yml: triggered on `.quorum-check` comments,
  allowlisted to the `registry-pilots` team via a read-org PAT.
  Tallies pilot 👍/👎 reactions against the policy, swaps
  in-review → accepted/rejected, dispatches the on-chain workflow on
  accept, closes+locks the issue on reject.
- registry-onchain-submit.yml: workflow_dispatch only. Re-fetches and
  re-validates the issue body (defense in depth), parses to CLI args
  via parse_intake_to_args.py, runs stellar-registry-cli from a
  protected GitHub Environment (`registry-testnet` / `registry-mainnet`)
  that gates the signer secret behind required reviewers, posts the tx
  hash back, labels `:submitted` or `:submission-failed`.
- parse_intake_to_args.py: single source of truth for kind → CLI
  subcommand + flags mapping; emits a download URL when the publish
  method is selected (workflow fetches the wasm before invoking).

Tied together, these expect the operator to have already created the
`registry-pilots` team, set `READ_ORG_MEMBERS_PAT`, generated a CI
keypair, called `set_manager(<CI_PUBKEY>)` once per network as registry
admin, and provisioned the `registry-{testnet,mainnet}` environments
with secrets and reviewers. See docs/ci-publishing.md (follow-up
commit) for the runbook.

Testable after merge (with bootstrap done): pilots vote on an
in-review issue, one comments `.quorum-check`, the on-chain workflow
pauses at the env gate, a reviewer approves, the tx hash is posted
back to the issue.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>