### PR TITLE
feat: allow --no-template option on init

### DIFF
--- a/crates/stellar-scaffold-cli/src/commands/init/instantiate.rs
+++ b/crates/stellar-scaffold-cli/src/commands/init/instantiate.rs
@@ -15,6 +15,24 @@ use crate::commands::{PackageManager, PackageManagerSpec};
 pub const TEMPLATES_DIR: &str = "templates";
 /// The directory selected template is promoted to
 pub const APP_DIR: &str = "app";
+/// Reserved `--template` value selecting the no-frontend layout. Not a
+/// directory under `templates/` — there is nothing to instantiate.
+pub const NO_FRONTEND: &str = "none";
+
+/// List of every JS-related file in the monorepo root that will be removed
+/// by the no-template CLI option. Only Rust/Cargo workspace remains.
+const NO_FRONTEND_REMOVALS: &[&str] = &[
+    TEMPLATES_DIR,
+    "app-lib",
+    "e2e",
+    "tests",
+    "scripts",
+    ".husky",
+    "node_modules",
+    "package.json",
+    "package-lock.json",
+    ".prettierignore",
+];
 
 /// The declared workspaces for the instantiated project. `e2e/` is kept (its
 /// self-adapting config targets the single `app/` post-init); `templates/*` is
@@ -39,6 +57,8 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error("malformed root package.json: {0}")]
     PackageJson(#[from] serde_json::Error),
+    #[error("malformed environments.toml: {0}")]
+    EnvToml(#[from] toml_edit::TomlError),
 }
 
 /// How `--template` (or the interactive prompt) selected a source.
@@ -52,11 +72,15 @@ pub enum TemplateSource {
     Framework(String),
     /// Community repo shorthand, e.g. `"org/repo#ref"`.
     Community(String),
+    /// The reserved `none` value: contracts only, no UI layer.
+    NoFrontend,
 }
 
-/// Parse a `--template` value into official or community source
+/// Parse a `--template` value into official, community, or no-frontend source
 pub fn parse_template_arg(value: &str) -> TemplateSource {
-    if value.contains('/') {
+    if value == NO_FRONTEND {
+        TemplateSource::NoFrontend
+    } else if value.contains('/') {
         TemplateSource::Community(value.to_string())
     } else {
         TemplateSource::Framework(value.to_string())
@@ -103,6 +127,50 @@ pub fn instantiate(root: &Path, framework: &str) -> Result<(), Error> {
 
     rewrite_root_workspaces(root)?;
     prune_e2e_snapshots(root)?;
+    Ok(())
+}
+
+/// Assemble the no-frontend layout: strip every JS workspace and node config
+/// from the acquired monorepo, leaving only the Cargo/contracts side, and set
+/// `client = false` on every contract in `environments.toml` so `build`/`watch`
+/// never generate (or deploy for) client packages there is no app to consume.
+pub fn instantiate_no_frontend(root: &Path) -> Result<(), Error> {
+    if !root.join(TEMPLATES_DIR).is_dir() {
+        return Err(Error::NoTemplatesDir);
+    }
+    for name in NO_FRONTEND_REMOVALS {
+        let path = root.join(name);
+        if path.is_dir() {
+            fs::remove_dir_all(&path)?;
+        } else if path.exists() {
+            fs::remove_file(&path)?;
+        }
+    }
+    disable_clients_in_env_toml(root)
+}
+
+/// Set `client = false` on every contract entry in every environment of
+/// `environments.toml`, preserving formatting and comments. Contracts absent
+/// from the file default to `client = true` at build time, so only listed
+/// entries need rewriting — the shipped monorepo lists all of its contracts.
+fn disable_clients_in_env_toml(root: &Path) -> Result<(), Error> {
+    let path = root.join("environments.toml");
+    let Ok(contents) = fs::read_to_string(&path) else {
+        return Ok(());
+    };
+    let mut doc: toml_edit::DocumentMut = contents.parse()?;
+    for (_, env) in doc.iter_mut() {
+        let Some(contracts) = env.get_mut("contracts").and_then(|c| c.as_table_like_mut()) else {
+            continue;
+        };
+        let names: Vec<String> = contracts.iter().map(|(k, _)| k.to_string()).collect();
+        for name in names {
+            if let Some(contract) = contracts.get_mut(&name).and_then(|c| c.as_table_like_mut()) {
+                contract.insert("client", toml_edit::value(false));
+            }
+        }
+    }
+    fs::write(&path, doc.to_string())?;
     Ok(())
 }
 
@@ -226,6 +294,11 @@ mod tests {
     }
 
     #[test]
+    fn parse_template_arg_none_is_no_frontend() {
+        assert_eq!(parse_template_arg("none"), TemplateSource::NoFrontend);
+    }
+
+    #[test]
     fn parse_template_arg_community_when_slash() {
         assert_eq!(
             parse_template_arg("org/repo#tutorial"),
@@ -312,6 +385,107 @@ mod tests {
         }
         // failure leaves the monorepo untouched
         assert!(dir.path().join("templates/react").exists());
+    }
+
+    /// Extend the base fixture with the Cargo side + env toml the no-frontend
+    /// layout keeps, and the extra node config it strips.
+    fn no_frontend_fixture() -> tempfile::TempDir {
+        let dir = fixture();
+        let root = dir.path();
+        write(&root.join("Cargo.toml"), "[workspace]\n");
+        write(&root.join("scaffold.yml"), "version: 1\n");
+        write(
+            &root.join("environments.toml"),
+            "# top comment\n\
+             [development.contracts]\n\
+             fungible = { client = true, constructor_args = \"--admin me\" }\n\
+             \n\
+             # section-style contract\n\
+             [development.contracts.guess_the_number]\n\
+             client = true\n\
+             \n\
+             [staging.contracts.other]\n\
+             id = \"C123\"\n",
+        );
+        write(&root.join("tests/e2e/smoke.spec.ts"), "// smoke");
+        write(&root.join("scripts/dev-guard.mjs"), "// guard");
+        write(&root.join(".husky/pre-commit"), "npm test");
+        write(&root.join(".prettierignore"), "target\n");
+        dir
+    }
+
+    #[test]
+    fn no_frontend_strips_js_and_keeps_cargo_side() {
+        let dir = no_frontend_fixture();
+        let root = dir.path();
+        instantiate_no_frontend(root).unwrap();
+
+        for gone in [
+            "templates",
+            "app-lib",
+            "e2e",
+            "tests",
+            "scripts",
+            ".husky",
+            "package.json",
+            ".prettierignore",
+        ] {
+            assert!(!root.join(gone).exists(), "{gone} removed");
+        }
+        for kept in [
+            "Cargo.toml",
+            "scaffold.yml",
+            "environments.toml",
+            "contracts",
+        ] {
+            assert!(root.join(kept).exists(), "{kept} kept");
+        }
+        assert!(!root.join(APP_DIR).exists(), "no app/ promoted");
+    }
+
+    #[test]
+    fn no_frontend_disables_clients_in_env_toml() {
+        let dir = no_frontend_fixture();
+        let root = dir.path();
+        instantiate_no_frontend(root).unwrap();
+
+        let contents = fs::read_to_string(root.join("environments.toml")).unwrap();
+        assert!(contents.contains("# top comment"), "comments preserved");
+        assert!(!contents.contains("client = true"));
+
+        let parsed: toml::Value = toml::from_str(&contents).unwrap();
+        for (env, name) in [
+            ("development", "fungible"),
+            ("development", "guess_the_number"),
+            ("staging", "other"),
+        ] {
+            assert_eq!(
+                parsed[env]["contracts"][name]["client"],
+                toml::Value::Boolean(false),
+                "{env}.{name} client disabled"
+            );
+        }
+        assert_eq!(
+            parsed["development"]["contracts"]["fungible"]["constructor_args"],
+            toml::Value::String("--admin me".into()),
+            "other settings untouched"
+        );
+    }
+
+    #[test]
+    fn no_frontend_errors_without_templates_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(matches!(
+            instantiate_no_frontend(dir.path()),
+            Err(Error::NoTemplatesDir)
+        ));
+    }
+
+    #[test]
+    fn no_frontend_ok_without_environments_toml() {
+        let dir = fixture();
+        instantiate_no_frontend(dir.path()).unwrap();
+        assert!(!dir.path().join("templates").exists());
     }
 
     fn spec(kind: PackageManager) -> PackageManagerSpec {

--- a/crates/stellar-scaffold-cli/src/commands/init/mod.rs
+++ b/crates/stellar-scaffold-cli/src/commands/init/mod.rs
@@ -38,10 +38,15 @@ pub struct Cmd {
 
     /// Template selector. A bare framework name (e.g. `react`) picks an official
     /// template from the UI monorepo; a `user/repo` shorthand (optionally with a
-    /// `#branch`/`#tag` suffix) degits that community repo directly. Omit to
-    /// choose a framework interactively.
+    /// `#branch`/`#tag` suffix) degits that community repo directly; `none`
+    /// creates a contracts-only project with no frontend. Omit to choose
+    /// interactively.
     #[arg(long)]
     pub template: Option<String>,
+
+    /// Create a contracts-only project with no frontend (alias for `--template none`)
+    #[arg(long, conflicts_with = "template")]
+    pub no_template: bool,
 
     /// Specify package manager, omitting will prompt interactively
     #[arg(short = 'p', long)]
@@ -83,6 +88,8 @@ enum Source {
     Official(Option<String>),
     /// Community repo shorthand, degit'd as-is.
     Community(String),
+    /// Contracts only: monorepo acquired, all JS stripped, no `app/`.
+    NoFrontend,
 }
 
 impl Cmd {
@@ -104,22 +111,56 @@ impl Cmd {
             absolute_project_path.display()
         ));
 
-        // Resolve the source from --template using the slash heuristic.
-        let source = match &self.template {
-            None => Source::Official(None),
-            Some(s) => match instantiate::parse_template_arg(s) {
-                instantiate::TemplateSource::Framework(name) => Source::Official(Some(name)),
-                instantiate::TemplateSource::Community(repo) => Source::Community(repo),
-            },
+        // Resolve the source from --no-template / --template (slash heuristic).
+        let source = if self.no_template {
+            Source::NoFrontend
+        } else {
+            match &self.template {
+                None => Source::Official(None),
+                Some(s) => match instantiate::parse_template_arg(s) {
+                    instantiate::TemplateSource::Framework(name) => Source::Official(Some(name)),
+                    instantiate::TemplateSource::Community(repo) => Source::Community(repo),
+                    instantiate::TemplateSource::NoFrontend => Source::NoFrontend,
+                },
+            }
         };
 
         let repo = match &source {
-            Source::Official(_) => ui_repo(),
+            Source::Official(_) | Source::NoFrontend => ui_repo(),
             Source::Community(repo) => repo.clone(),
         };
 
         // acquire: degit the chosen repo into the project path.
         acquire(&repo, &absolute_project_path).await?;
+
+        // Settle the framework choice before anything package-manager related:
+        // the interactive prompt can pick "none", which has no JS to manage.
+        let source = match source {
+            Source::Official(None) => match select_framework(&absolute_project_path, self.yes)? {
+                Some(framework) => Source::Official(Some(framework)),
+                None => Source::NoFrontend,
+            },
+            other => other,
+        };
+
+        if matches!(source, Source::NoFrontend) {
+            // instantiate: strip the UI layer entirely; no package manager.
+            instantiate::instantiate_no_frontend(&absolute_project_path)?;
+
+            // prepare: build contracts, git — no dependency install.
+            setup::prepare(&absolute_project_path, None, global_args, self.yes).await?;
+
+            printer.blankln("\n\n");
+            printer.checkln(format!(
+                "Project successfully created at {}!",
+                absolute_project_path.display()
+            ));
+            printer.blankln(" You can now build your contracts with:\n");
+            printer.blankln(format!("\tcd {}", self.project_path.display()));
+            printer.blankln("\tstellar scaffold build");
+            printer.blankln("\n Happy hacking! 🚀");
+            return Ok(());
+        }
 
         // Gather the package-manager choice up front (both paths need it).
         // `--template` signals non-interactive intent (the framework is already
@@ -134,22 +175,26 @@ impl Cmd {
 
         // instantiate: official templates promote one framework + apply pkg-mgr fs.
         match &source {
-            Source::Official(framework) => {
-                let framework = match framework {
-                    Some(name) => name.clone(),
-                    None => select_framework(&absolute_project_path, self.yes)?,
-                };
-                instantiate::instantiate(&absolute_project_path, &framework)?;
+            Source::Official(Some(framework)) => {
+                instantiate::instantiate(&absolute_project_path, framework)?;
                 instantiate::apply_package_manager(&absolute_project_path, &pkg_manager)?;
             }
             Source::Community(_) => {
                 // Community repos own their own layout; just record the manager.
                 let _ = pkg_manager.write_to_package_json(&absolute_project_path);
             }
+            // Both settled above.
+            Source::Official(None) | Source::NoFrontend => unreachable!(),
         }
 
         // prepare: install, build, git.
-        setup::prepare(&absolute_project_path, &pkg_manager, global_args, self.yes).await?;
+        setup::prepare(
+            &absolute_project_path,
+            Some(&pkg_manager),
+            global_args,
+            self.yes,
+        )
+        .await?;
 
         let pm_command = pkg_manager.kind.command();
         printer.blankln("\n\n");
@@ -189,21 +234,24 @@ async fn acquire(repo: &str, project_path: &Path) -> Result<(), Error> {
 }
 
 /// Prompt for a framework from those available in the acquired monorepo, or pick
-/// the first when running non-interactively.
-fn select_framework(root: &Path, yes: bool) -> Result<String, Error> {
+/// the first when running non-interactively. Returns `None` when the user picks
+/// the "none" (no frontend) choice.
+fn select_framework(root: &Path, yes: bool) -> Result<Option<String>, Error> {
     let frameworks = instantiate::enumerate_templates(root)?;
     if frameworks.is_empty() {
         return Err(Error::Instantiate(instantiate::Error::NoTemplatesDir));
     }
-    if yes || frameworks.len() == 1 {
-        return Ok(frameworks[0].clone());
+    if yes {
+        return Ok(Some(frameworks[0].clone()));
     }
+    let mut items = frameworks.clone();
+    items.push(format!("{} (no frontend)", instantiate::NO_FRONTEND));
     let index = Select::with_theme(&ColorfulTheme::default())
         .with_prompt("Pick a framework")
-        .items(&frameworks)
+        .items(&items)
         .default(0)
         .interact()
         .ok()
         .ok_or(Error::Cancelled)?;
-    Ok(frameworks[index].clone())
+    Ok(frameworks.get(index).cloned())
 }

--- a/crates/stellar-scaffold-cli/src/commands/setup.rs
+++ b/crates/stellar-scaffold-cli/src/commands/setup.rs
@@ -29,10 +29,11 @@ pub enum Error {
 /// project's files are in place. Package-manager *selection* and *file writes*
 /// happen earlier (in `init` and `instantiate`); this takes the already-chosen
 /// manager and does environment setup, dependency install, contract build, and
-/// git init.
+/// git init. `pkg_manager` is `None` for no-frontend projects, which have no
+/// JS dependencies to install.
 pub async fn prepare(
     project_path: &Path,
-    pkg_manager: &PackageManagerSpec,
+    pkg_manager: Option<&PackageManagerSpec>,
     global_args: &global::Args,
     yes: bool,
 ) -> Result<(), Error> {
@@ -62,13 +63,18 @@ pub async fn prepare(
 
     ensure_extensions_installed(project_path, &printer, yes);
 
-    let pm_command = pkg_manager.kind.command();
-    run_install(pm_command, project_path, &printer);
-
-    printer.infoln("Compiling contracts and generating client packages...");
+    if let Some(pkg_manager) = pkg_manager {
+        run_install(pkg_manager.kind.command(), project_path, &printer);
+        printer.infoln("Compiling contracts and generating client packages...");
+    } else {
+        printer.infoln("Compiling contracts...");
+    }
     let mut build_command = build::Command::parse_from(["build"]);
     build_command.build.manifest_path = Some(project_path.join("Cargo.toml"));
-    build_command.build_clients = true;
+    // The clients pipeline needs a network (account funding, deploys) even when
+    // every contract opts out with `client = false`; a no-frontend project has
+    // no clients to generate, so skip it and just compile.
+    build_command.build_clients = pkg_manager.is_some();
     let mut build_args = global_args.clone();
     if !(global_args.verbose && global_args.very_verbose) {
         build_args.quiet = true;

--- a/docs/site/docs/cli.md
+++ b/docs/site/docs/cli.md
@@ -13,12 +13,16 @@ stellar scaffold init <project-path> [name]
 Options:
 
 - `project-path`: Required. The path where the project will be created
+- `--template <name>`: Template selector. A bare framework name (e.g. `react`) picks an official template; a `user/repo` shorthand (optionally with `#branch`) uses a community template; `none` creates a contracts-only project with no frontend. Omit to choose interactively
+- `--no-template`: Create a contracts-only project with no frontend (alias for `--template none`)
 
 The init command creates:
 
 - A new Stellar smart contract project with best practices and configurations
 - A frontend application using the [scaffold-stellar-frontend](https://github.com/stellar-scaffold/ui) template
 - Configuration files for both contract and frontend development
+
+With `--no-template` (or `--template none`), the frontend layer is omitted entirely: no `app/`, no JS workspaces, no dependency install. Every contract in `environments.toml` is written with `client = false`, so `stellar scaffold build` and `watch` skip client package generation. Flip a contract back to `client = true` if you later need TypeScript clients.
 
 ## Generate Command
 


### PR DESCRIPTION
Removes all JS-related files from repo during project instantiation, including any config files used by npm packages since they won't be installed. Also skips package manager choice since unneeded. Then sets `client = false` in environments.toml for all contracts.

Closes #366 