### PR TITLE
fix(ci): restore app auth for CD

### DIFF
--- a/.github/workflows/cd-scaffold-cli.yml
+++ b/.github/workflows/cd-scaffold-cli.yml
@@ -11,6 +11,14 @@ on:
   pull_request:
     paths:
       - crates/stellar-scaffold-cli/CHANGELOG.md
+  # Allow manual escape hatch for tags that never fired this workflow, so a
+  # release missing its binaries can be backfilled without re-tagging.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build and upload assets for (e.g. stellar-scaffold-cli-v0.0.26)"
+        required: true
+        type: string
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_GIT_FETCH_WITH_CLI: true
@@ -52,6 +60,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - if: runner.os == 'Linux'
@@ -62,6 +72,7 @@ jobs:
         with:
           bin: stellar-scaffold
           target: ${{ matrix.target }}
+          ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || '' }}
           tar: all
           zip: windows
           archive: $tag-$target

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,21 @@ jobs:
       contents: write
       pull-requests: read
     steps:
+      # Tags and releases created with the default GITHUB_TOKEN never trigger
+      # other workflows, so use app to build and release binaries via CD action
+      - &generate-token
+        name: Generate GitHub token
+        uses: actions/create-github-app-token@v2
+        id: generate-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - &checkout
         name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          persist-credentials: false
+          token: ${{ steps.generate-token.outputs.token }}
       - &install-rust
         name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -32,7 +41,7 @@ jobs:
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   # Create a PR with the new versions and changelog, preparing the next release.
@@ -46,6 +55,7 @@ jobs:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
+      - *generate-token
       - *checkout
       - *install-rust
       - *install-deps
@@ -54,5 +64,5 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Reorganization for Stellar-Scaffold GH org dropped our app's authentication to release binaries because the new GITHUB_TOKEN workflow doesn't trigger new workflows. So the CD action never ran.

Also adds an escape hatch to manually run release without re-tagging.